### PR TITLE
Fall back to demo login when production API lacks /auth/demo.

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,23 @@
 import axios from 'axios';
 import { api, type LoginResponse, type Shop } from './client';
+import {
+  DEMO_PIN,
+  DEMO_SECTOR_FALLBACK,
+  demoUsernameForSector,
+  isKnownDemoUsername,
+} from '@/constants/demoSectors';
+
+function markDemoShop(shop: Shop, sector?: string): Shop {
+  if (!shop) return shop;
+  if (shop.isDemo || isKnownDemoUsername(shop.username)) {
+    return {
+      ...shop,
+      isDemo: true,
+      demoSector: shop.demoSector || sector || null,
+    };
+  }
+  return shop;
+}
 
 export async function login(
   username: string,
@@ -10,6 +28,9 @@ export async function login(
       username,
       pin,
     });
+    if (data.success && data.shop) {
+      data.shop = markDemoShop(data.shop);
+    }
     return data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
@@ -27,9 +48,30 @@ export async function enterDemo(sector?: string): Promise<LoginResponse> {
     const { data } = await api.post<LoginResponse>('/auth/demo', {
       sector: sector || undefined,
     });
+    if (data.success && data.shop) {
+      data.shop = markDemoShop(data.shop, sector);
+    }
     return data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      // Stale production API (pre demo-shop deploy): fall back to demo login.
+      if (status === 404 || status === 405) {
+        const username = demoUsernameForSector(sector);
+        const viaLogin = await login(username, DEMO_PIN);
+        if (viaLogin.success && viaLogin.shop) {
+          viaLogin.shop = markDemoShop(viaLogin.shop, sector);
+          return viaLogin;
+        }
+        return {
+          success: false,
+          token: '',
+          shop: null as unknown as Shop,
+          error:
+            viaLogin.error ||
+            'Demo login failed. Redeploy the API with /auth/demo, or run seed:demos.',
+        };
+      }
       const message =
         (error.response?.data as { error?: string } | undefined)?.error ||
         'Demo is unavailable';
@@ -49,10 +91,18 @@ export type DemoSector = {
 };
 
 export async function listDemos(): Promise<DemoSector[]> {
-  const { data } = await api.get<{ success: boolean; demos: DemoSector[] }>(
-    '/auth/demos',
-  );
-  return data.demos || [];
+  try {
+    const { data } = await api.get<{ success: boolean; demos: DemoSector[] }>(
+      '/auth/demos',
+    );
+    return data.demos || [];
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      // API not redeployed yet — still show the sector picker.
+      return DEMO_SECTOR_FALLBACK.map((s) => ({ ...s, available: true }));
+    }
+    throw error;
+  }
 }
 
 export type RegisterInput = {
@@ -88,7 +138,7 @@ export async function logout(): Promise<void> {
 
 export async function fetchMe(): Promise<Shop> {
   const { data } = await api.get<{ success: boolean; shop: Shop }>('/auth/me');
-  return data.shop;
+  return markDemoShop(data.shop);
 }
 
 export type { StatsOverview } from './stats';

--- a/frontend/src/constants/demoSectors.ts
+++ b/frontend/src/constants/demoSectors.ts
@@ -1,0 +1,70 @@
+/**
+ * Client-side demo catalog (mirrors backend/constants/demoSectors.js ids).
+ * Used when the API has not been redeployed with /auth/demos yet.
+ */
+export const DEMO_SECTOR_FALLBACK = [
+  {
+    id: 'groceries',
+    label: 'Groceries & spaza',
+    blurb: 'Fast movers, airtime, and daily cash — busy till energy.',
+    businessName: 'Corner Fresh',
+    username: 'groceries_demo',
+    available: true,
+  },
+  {
+    id: 'clothing',
+    label: 'Clothing boutique',
+    blurb: 'Dresses, separates, and accessories — fashion floor feel.',
+    businessName: 'Luna Atelier',
+    username: 'boutique_demo',
+    available: true,
+  },
+  {
+    id: 'jewellery',
+    label: 'Jewellery',
+    blurb: 'Pieces with presence — browse, sell, and track stock.',
+    businessName: 'Aura Gems',
+    username: 'jewellery_demo',
+    available: true,
+  },
+  {
+    id: 'hardware',
+    label: 'Hardware',
+    blurb: 'Yard staples and project essentials.',
+    businessName: 'BuildRight Yard',
+    username: 'hardware_demo',
+    available: true,
+  },
+  {
+    id: 'salon',
+    label: 'Salon & beauty',
+    blurb: 'Services and products — chair-side till energy.',
+    businessName: 'Glow Studio',
+    username: 'salon_demo',
+    available: true,
+  },
+  {
+    id: 'pharmacy',
+    label: 'Pharmacy',
+    blurb: 'OTC and essentials with careful stock habits.',
+    businessName: 'WellPath Chemist',
+    username: 'pharmacy_demo',
+    available: true,
+  },
+] as const;
+
+/** Shared PIN for all seeded demo shops. */
+export const DEMO_PIN = '4829';
+
+export function demoUsernameForSector(sectorId?: string): string {
+  const id = String(sectorId || 'clothing').toLowerCase();
+  const match = DEMO_SECTOR_FALLBACK.find((s) => s.id === id);
+  return match?.username || 'boutique_demo';
+}
+
+export function isKnownDemoUsername(username?: string | null): boolean {
+  const u = String(username || '').toLowerCase();
+  if (!u) return false;
+  if (u.endsWith('_demo')) return true;
+  return DEMO_SECTOR_FALLBACK.some((s) => s.username === u);
+}


### PR DESCRIPTION
Unblocks Try demo on Vercel while Render is still on a pre-demo deploy; marks known demo usernames as read-only on the client.