### PR TITLE
Add username policy and hashed recovery-code PIN reset.

### DIFF
--- a/backend/controllers/api/authController.js
+++ b/backend/controllers/api/authController.js
@@ -1,6 +1,7 @@
 import Shop from "../../models/Shop.js";
 import AuthService from "../../services/AuthService.js";
 import ActivityService from "../../services/ActivityService.js";
+import SessionStore from "../../services/sessionStore.js";
 import { publicShop, stripMarkdown } from "../../utils/apiResponse.js";
 import { normalizeUsername } from "../../utils/channelIdentity.js";
 import {
@@ -242,6 +243,9 @@ export async function register(req, res) {
       return res.status(status).json({
         success: false,
         error: stripMarkdown(result.message),
+        ...(result.suggestions?.length
+          ? { suggestions: result.suggestions }
+          : {}),
       });
     }
 
@@ -258,6 +262,8 @@ export async function register(req, res) {
       success: true,
       token: result.sessionToken,
       shop: publicShop(result.shop),
+      // Shown once — client must display immediately; never persisted server-side as plaintext.
+      recoveryCodes: result.recoveryCodes || [],
     });
   } catch (error) {
     console.error("[api/auth/register]", error);
@@ -292,6 +298,45 @@ export async function status(req, res) {
     return res.status(500).json({
       success: false,
       error: "Failed to get status.",
+    });
+  }
+}
+
+/** Real-time username availability for registration / profile edit. */
+export async function checkUsername(req, res) {
+  try {
+    const username = String(
+      req.query.username || req.body?.username || ""
+    ).trim();
+    if (!username) {
+      return res.status(400).json({
+        success: false,
+        error: "username is required.",
+      });
+    }
+
+    let excludeShopId = null;
+    const header = req.get("Authorization") || "";
+    const match = header.match(/^Bearer\s+(.+)$/i);
+    if (match) {
+      const session = await SessionStore.getLoginSessionByToken(
+        match[1].trim()
+      );
+      if (session?.shopId) excludeShopId = session.shopId;
+    }
+
+    const result = await AuthService.checkUsernameAvailability(username, {
+      excludeShopId,
+    });
+    return res.json({
+      success: true,
+      ...result,
+    });
+  } catch (error) {
+    console.error("[api/auth/username]", error);
+    return res.status(500).json({
+      success: false,
+      error: "Failed to check username.",
     });
   }
 }
@@ -344,6 +389,54 @@ export async function updateProfileName(req, res) {
     return res.status(500).json({
       success: false,
       error: "Failed to update name.",
+    });
+  }
+}
+
+export async function updateProfileUsername(req, res) {
+  try {
+    const username = String(
+      req.body?.username || req.body?.userId || ""
+    ).trim();
+    if (!username) {
+      return res.status(400).json({
+        success: false,
+        error: "username is required.",
+      });
+    }
+
+    const result = await AuthService.updateUsernameForShop(req.shop, username);
+    if (!result.success) {
+      const status = /taken|already/i.test(result.message) ? 409 : 400;
+      return res.status(status).json({
+        success: false,
+        error: stripMarkdown(result.message),
+        ...(result.suggestions?.length
+          ? { suggestions: result.suggestions }
+          : {}),
+      });
+    }
+
+    const shop = await Shop.findById(req.shopId);
+    await ActivityService.log({
+      shopId: shop._id,
+      userId: shop.username,
+      channel: req.channel || "web",
+      action: "auth.username",
+      summary: result.message,
+      entityType: "shop",
+    });
+
+    return res.json({
+      success: true,
+      shop: publicShop(shop),
+      message: stripMarkdown(result.message),
+    });
+  } catch (error) {
+    console.error("[api/auth/profile/username]", error);
+    return res.status(500).json({
+      success: false,
+      error: "Failed to update username.",
     });
   }
 }
@@ -436,6 +529,111 @@ export async function updateProfilePin(req, res) {
     return res.status(500).json({
       success: false,
       error: "Failed to update PIN.",
+    });
+  }
+}
+
+/** Public: reset PIN with a one-time recovery code. */
+export async function redeemRecovery(req, res) {
+  try {
+    const username = String(
+      req.body?.username || req.body?.userId || ""
+    ).trim();
+    const code = String(req.body?.code || req.body?.recoveryCode || "").trim();
+    const newPin = String(req.body?.newPin || req.body?.pin || "").trim();
+
+    if (!username || !code || !newPin) {
+      return res.status(400).json({
+        success: false,
+        error: "username, code, and newPin are required.",
+      });
+    }
+
+    const result = await AuthService.redeemRecoveryCode({
+      username,
+      code,
+      newPin,
+    });
+
+    if (!result.success) {
+      const locked = /locked|too many/i.test(result.message || "");
+      return res.status(locked ? 429 : 401).json({
+        success: false,
+        error: stripMarkdown(result.message),
+      });
+    }
+
+    await ActivityService.log({
+      shopId: (await AuthService.findShopByUsername(username))?._id,
+      userId: normalizeUsername(username),
+      channel: "web",
+      action: "auth.recovery",
+      summary: "PIN reset with recovery code",
+      entityType: "shop",
+    });
+
+    return res.json({
+      success: true,
+      message: result.message,
+      remaining: result.remaining,
+      mustRegenerate: result.mustRegenerate,
+    });
+  } catch (error) {
+    console.error("[api/auth/recovery/redeem]", error);
+    return res.status(500).json({
+      success: false,
+      error: "Recovery failed.",
+    });
+  }
+}
+
+/** Authenticated: status of unused recovery codes (no plaintext). */
+export async function recoveryStatus(req, res) {
+  try {
+    const status = await AuthService.getRecoveryCodeStatus(req.shopId);
+    return res.json({ success: true, ...status });
+  } catch (error) {
+    console.error("[api/auth/recovery]", error);
+    return res.status(500).json({
+      success: false,
+      error: "Failed to get recovery status.",
+    });
+  }
+}
+
+/** Authenticated: revoke unused codes and issue a new set (shown once). */
+export async function regenerateRecovery(req, res) {
+  try {
+    const result = await AuthService.issueRecoveryCodesForShop(req.shop, {
+      revokeExisting: true,
+    });
+    if (!result.success) {
+      return res.status(400).json({
+        success: false,
+        error: result.message,
+      });
+    }
+
+    await ActivityService.log({
+      shopId: req.shopId,
+      userId: req.username,
+      channel: req.channel || "web",
+      action: "auth.recovery.regenerate",
+      summary: "Issued a new recovery code set",
+      entityType: "shop",
+    });
+
+    return res.json({
+      success: true,
+      message: result.message,
+      recoveryCodes: result.codes,
+      remaining: result.remaining,
+    });
+  } catch (error) {
+    console.error("[api/auth/recovery/regenerate]", error);
+    return res.status(500).json({
+      success: false,
+      error: "Failed to regenerate recovery codes.",
     });
   }
 }

--- a/backend/controllers/api/helpController.js
+++ b/backend/controllers/api/helpController.js
@@ -16,10 +16,21 @@ const ENDPOINTS = [
   },
   {
     method: "PATCH",
+    path: "/auth/profile/username",
+    command: "profile edit username",
+  },
+  {
+    method: "PATCH",
     path: "/auth/profile/description",
     command: "profile edit description",
   },
   { method: "PATCH", path: "/auth/profile/pin", command: "profile edit pin" },
+  { method: "POST", path: "/auth/recovery/redeem", command: "recover" },
+  {
+    method: "POST",
+    path: "/auth/recovery/regenerate",
+    command: "settings recovery codes",
+  },
   { method: "GET", path: "/products", command: "list / products" },
   { method: "POST", path: "/products", command: "add" },
   { method: "GET", path: "/products/low-stock", command: "low stock" },

--- a/backend/models/RecoveryCode.js
+++ b/backend/models/RecoveryCode.js
@@ -1,0 +1,45 @@
+import mongoose from "mongoose";
+
+/**
+ * Hashed recovery codes for PIN reset.
+ * Plaintext is never stored — only shown once at issue time.
+ */
+const recoveryCodeSchema = new mongoose.Schema(
+  {
+    shopId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Shop",
+      required: true,
+      index: true,
+    },
+    /** HMAC-SHA256 hex of normalized code. */
+    codeHash: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    /** Groups codes issued together (for revoke-on-regenerate). */
+    batchId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+    usedAt: {
+      type: Date,
+      default: null,
+    },
+    revokedAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  { timestamps: false }
+);
+
+recoveryCodeSchema.index({ shopId: 1, usedAt: 1, revokedAt: 1 });
+
+export default mongoose.model("RecoveryCode", recoveryCodeSchema);

--- a/backend/models/Shop.js
+++ b/backend/models/Shop.js
@@ -15,7 +15,10 @@ const channelsSchema = new mongoose.Schema(
 );
 
 const shopSchema = new mongoose.Schema({
-  /** Canonical login identity — case-insensitive, unique. */
+  /** Canonical login identity — case-insensitive, unique.
+   * New registrations: 3–15 letters + optional trailing digits (see usernamePolicy).
+   * Schema stays permissive so grandfathered / demo usernames (underscores, ≤32) still save.
+   */
   username: {
     type: String,
     required: true,

--- a/backend/routes/api/v1.js
+++ b/backend/routes/api/v1.js
@@ -20,15 +20,28 @@ router.post("/auth/login", authController.login);
 router.get("/auth/demos", authController.listDemos);
 router.post("/auth/demo", authController.enterDemo);
 router.get("/auth/status", authController.status);
+router.get("/auth/username", authController.checkUsername);
+router.post("/auth/recovery/redeem", authController.redeemRecovery);
 
 // Auth (session)
 router.post("/auth/logout", requireApiAuth, authController.logout);
 router.get("/auth/me", requireApiAuth, authController.me);
 router.get("/auth/profile", requireApiAuth, authController.profile);
+router.get("/auth/recovery", requireApiAuth, authController.recoveryStatus);
+router.post(
+  "/auth/recovery/regenerate",
+  requireApiAuth,
+  authController.regenerateRecovery
+);
 router.patch(
   "/auth/profile/name",
   requireApiAuth,
   authController.updateProfileName
+);
+router.patch(
+  "/auth/profile/username",
+  requireApiAuth,
+  authController.updateProfileUsername
 );
 router.patch(
   "/auth/profile/description",

--- a/backend/scripts/e2ePhase3.js
+++ b/backend/scripts/e2ePhase3.js
@@ -16,7 +16,7 @@ import Customer from "../models/Customer.js";
 dotenv.config();
 
 const TG_CHAT = `${Date.now()}`.slice(-9);
-const USERNAME = `e2e3_${Date.now().toString(36)}`.slice(0, 32);
+const USERNAME = `e2e3${Date.now().toString().slice(-8)}`.slice(0, 15);
 const PIN = "4829";
 const results = [];
 

--- a/backend/scripts/e2ePhase5.js
+++ b/backend/scripts/e2ePhase5.js
@@ -36,10 +36,10 @@ const {
 const { handleTelegramUpdate } = await import("../adapters/telegram.js");
 
 const TG_CHAT = `${Date.now()}`.slice(-9);
-const TG_USER = `e2e5_tg_${Date.now().toString(36)}`.slice(0, 32);
+const TG_USER = `e2e5tg${Date.now().toString().slice(-7)}`.slice(0, 15);
 const WA_PHONE = "263771234567";
 const WA = `wa:${WA_PHONE}`;
-const WA_USER = `e2e5_wa_${Date.now().toString(36)}`.slice(0, 32);
+const WA_USER = `e2e5wa${Date.now().toString().slice(-7)}`.slice(0, 15);
 const PIN = "4829";
 const results = [];
 

--- a/backend/scripts/e2eRecovery.js
+++ b/backend/scripts/e2eRecovery.js
@@ -1,0 +1,228 @@
+/**
+ * End-to-end: register → recovery codes → change username → redeem → login.
+ *
+ * Usage:
+ *   TEST_MONGODB_URI=... node scripts/e2eRecovery.js
+ *   (falls back to MONGODB_URI / local phase4 DB like other tests)
+ */
+import http from "http";
+import assert from "node:assert/strict";
+
+if (!process.env.TELEGRAM_BOT_TOKEN) {
+  process.env.TELEGRAM_BOT_TOKEN = "000000000:E2E_RECOVERY_DUMMY";
+}
+
+const { connectTestDb, disconnectTestDb, wipeShopData } = await import(
+  "../tests/helpers/mongo.js"
+);
+const { default: createApp } = await import("../app.js");
+const { default: RecoveryCode } = await import("../models/RecoveryCode.js");
+const { hashRecoveryCode } = await import("../utils/recoveryCodes.js");
+
+function request(server, { method = "GET", path, body, token } = {}) {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const payload = body != null ? JSON.stringify(body) : null;
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: addr.port,
+        path,
+        method,
+        headers: {
+          ...(payload
+            ? {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(payload),
+              }
+            : {}),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => {
+          let json = null;
+          try {
+            json = data ? JSON.parse(data) : null;
+          } catch {
+            json = data;
+          }
+          resolve({ status: res.statusCode, body: json });
+        });
+      }
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+const results = [];
+function check(name, cond, detail = "") {
+  results.push({ name, ok: !!cond, detail: String(detail).slice(0, 200) });
+  console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? ` — ${String(detail).slice(0, 120)}` : ""}`);
+}
+
+const stamp = Date.now().toString().slice(-8);
+const username = `eerecv${stamp}`.slice(0, 15);
+const pin = "4829";
+const newPin = "5731";
+const renamed = `eerenm${stamp}`.slice(0, 15);
+
+await connectTestDb();
+const app = createApp();
+const server = await new Promise((resolve) => {
+  const s = app.listen(0, "127.0.0.1", () => resolve(s));
+});
+
+let shopId = null;
+
+try {
+  // 1. Register
+  const reg = await request(server, {
+    method: "POST",
+    path: "/api/v1/auth/register",
+    body: {
+      username,
+      businessName: `E2E Recovery ${stamp}`,
+      pin,
+      businessDescription: "End to end recovery codes test shop",
+    },
+  });
+  check("register 201", reg.status === 201, JSON.stringify(reg.body?.error || ""));
+  check("returns 8 recovery codes", reg.body?.recoveryCodes?.length === 8);
+  check("codes look like cs-xxxx-xxxx", /^cs-[a-z0-9]{4}-[a-z0-9]{4}$/.test(reg.body?.recoveryCodes?.[0] || ""));
+  const token = reg.body?.token;
+  shopId = reg.body?.shop?.id;
+  const codes = reg.body?.recoveryCodes || [];
+
+  // 2. Hashes only in DB
+  const stored = await RecoveryCode.find({ shopId }).lean();
+  check("8 hashes stored", stored.length === 8);
+  check(
+    "no plaintext in DB",
+    stored.every((row) => !codes.includes(row.codeHash) && row.codeHash.length === 64)
+  );
+  check(
+    "hash matches issued code",
+    stored.some((row) => row.codeHash === hashRecoveryCode(codes[0]))
+  );
+
+  // 3. Status while authed
+  const status = await request(server, {
+    method: "GET",
+    path: "/api/v1/auth/recovery",
+    token,
+  });
+  check("recovery status remaining=8", status.status === 200 && status.body.remaining === 8);
+
+  // 4. Username availability (self = available)
+  const selfCheck = await request(server, {
+    method: "GET",
+    path: `/api/v1/auth/username?username=${encodeURIComponent(username)}`,
+    token,
+  });
+  check("own username available when authed", selfCheck.body?.available === true);
+
+  // 5. Change username
+  const renamedRes = await request(server, {
+    method: "PATCH",
+    path: "/api/v1/auth/profile/username",
+    token,
+    body: { username: renamed },
+  });
+  check("username change 200", renamedRes.status === 200, JSON.stringify(renamedRes.body?.error || ""));
+  check("shop username updated", renamedRes.body?.shop?.username === renamed);
+
+  // 6. Regenerate codes
+  const regen = await request(server, {
+    method: "POST",
+    path: "/api/v1/auth/recovery/regenerate",
+    token,
+  });
+  check("regenerate 200", regen.status === 200);
+  check("regen returns 8 new codes", regen.body?.recoveryCodes?.length === 8);
+  const freshCodes = regen.body?.recoveryCodes || [];
+  check(
+    "old code set revoked (old plaintext unused)",
+    !freshCodes.includes(codes[0])
+  );
+
+  // 7. Old code from first set should fail after revoke
+  const oldRedeem = await request(server, {
+    method: "POST",
+    path: "/api/v1/auth/recovery/redeem",
+    body: { username: renamed, code: codes[0], newPin },
+  });
+  check("revoked code rejected", oldRedeem.status === 401);
+
+  // 8. Redeem a fresh code
+  const redeem = await request(server, {
+    method: "POST",
+    path: "/api/v1/auth/recovery/redeem",
+    body: { username: renamed, code: freshCodes[0], newPin },
+  });
+  check("redeem 200", redeem.status === 200, JSON.stringify(redeem.body?.error || ""));
+  check("remaining=7", redeem.body?.remaining === 7);
+
+  // 9. Reuse same code fails
+  const reuse = await request(server, {
+    method: "POST",
+    path: "/api/v1/auth/recovery/redeem",
+    body: { username: renamed, code: freshCodes[0], newPin: "5820" },
+  });
+  check("used code rejected", reuse.status === 401);
+
+  // 10. Old PIN fails; new PIN works; old username fails
+  const badPin = await request(server, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    body: { username: renamed, pin },
+  });
+  check("old PIN rejected", badPin.status === 401);
+
+  const oldUser = await request(server, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    body: { username, pin: newPin },
+  });
+  check("old username rejected", oldUser.status === 401);
+
+  const okLogin = await request(server, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    body: { username: renamed, pin: newPin },
+  });
+  check("login with new username+PIN", okLogin.status === 200);
+
+  // 11. Reserved username blocked
+  const reserved = await request(server, {
+    method: "GET",
+    path: "/api/v1/auth/username?username=admin",
+  });
+  check(
+    "reserved username suggestions",
+    reserved.body?.available === false &&
+      reserved.body?.valid === false &&
+      (reserved.body?.suggestions?.length || 0) >= 1
+  );
+} finally {
+  if (shopId) {
+    await wipeShopData({ shopId, username: renamed });
+    await wipeShopData({ username });
+  }
+  await new Promise((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+  await disconnectTestDb();
+}
+
+const failed = results.filter((r) => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} passed`);
+if (failed.length) {
+  console.error("Failed:", failed.map((f) => f.name).join(", "));
+  process.exit(1);
+}
+console.log("E2E recovery flow OK");

--- a/backend/services/AuthService.js
+++ b/backend/services/AuthService.js
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import bcrypt from "bcryptjs";
 import Shop from "../models/Shop.js";
+import RecoveryCode from "../models/RecoveryCode.js";
 import SessionStore, {
   SESSION_TTL_MS,
   REGISTRATION_TTL_MS,
@@ -10,6 +11,18 @@ import {
   normalizeUsername,
   shopChannelQuery,
 } from "../utils/channelIdentity.js";
+import {
+  validateUsername as validateUsernamePolicy,
+  isUsernameShaped,
+  suggestUsernames,
+} from "../utils/usernamePolicy.js";
+import {
+  RECOVERY_CODE_COUNT,
+  generateRecoveryCodeBatch,
+  hashRecoveryCode,
+  normalizeRecoveryCode,
+  recoveryCodesMatch,
+} from "../utils/recoveryCodes.js";
 
 class AuthService {
   constructor() {
@@ -128,8 +141,8 @@ class AuthService {
           "*Welcome! Let's set up your business*\n\n" +
           "*Step 1 of 4: Username*\n\n" +
           "Choose a username you will use on web, Telegram, and WhatsApp.\n\n" +
-          "*Rules:* 3–32 characters, letters, numbers, underscore only.\n\n" +
-          "*Examples:* `tinasales`, `corner_shop`, `mikes_electronics`\n\n" +
+          "*Rules:* 3–15 characters, lowercase letters only, optional digits at the end.\n\n" +
+          "*Examples:* `musa`, `musa7`, `devking`\n\n" +
           "_(Type your username below)_",
       };
     } catch (error) {
@@ -207,22 +220,42 @@ class AuthService {
   async handleUsernameStep(channel, channelKey, usernameInput, session) {
     const validation = this.validateUsername(usernameInput);
     if (!validation.valid) {
+      const suggestions = await this.suggestAvailableUsernames(usernameInput);
+      const suggestionLines =
+        suggestions.length > 0
+          ? "\n*Try:*\n" +
+            suggestions.map((s) => `• \`${s}\``).join("\n") +
+            "\n\n"
+          : "\n\n";
       return {
         success: false,
         step: "username",
-        message: `*${validation.message}*\n\n_Please enter a valid username:_`,
+        suggestions,
+        message:
+          `*${validation.message}*` +
+          suggestionLines +
+          "_Please enter a valid username:_",
       };
     }
 
-    const username = normalizeUsername(usernameInput);
+    const username = validation.normalized;
     const existing = await this.findShopByUsername(username);
     if (existing) {
+      const suggestions = await this.suggestAvailableUsernames(username);
+      const suggestionLines =
+        suggestions.length > 0
+          ? "\n*Try:*\n" +
+            suggestions.map((s) => `• \`${s}\``).join("\n") +
+            "\n\n"
+          : "\n\n";
       return {
         success: false,
         step: "username",
+        suggestions,
         message:
           "*Username already taken*\n\n" +
-          `"${username}" is already registered.\n\n` +
+          `"${username}" is already registered.` +
+          suggestionLines +
           "_Please choose a different username:_",
       };
     }
@@ -370,16 +403,19 @@ class AuthService {
       return result;
     }
 
+    const codesBlock = this.formatRecoveryCodesMessage(result.recoveryCodes);
     return {
       success: true,
       completed: true,
       sessionToken: result.sessionToken,
       shop: result.shop,
+      recoveryCodes: result.recoveryCodes,
       message:
         "*Registration Complete!*\n\n" +
         `Welcome to *${session.data.businessName}*!\n\n` +
         `Username: \`${session.data.username}\`\n\n` +
         "Use this username + PIN on web, Telegram, and WhatsApp.\n\n" +
+        codesBlock +
         "*Quick Start:*\n" +
         "• help - See all commands\n\n" +
         "_You're logged in and ready to go!_",
@@ -399,7 +435,12 @@ class AuthService {
   }) {
     const usernameValidation = this.validateUsername(username);
     if (!usernameValidation.valid) {
-      return { success: false, message: usernameValidation.message };
+      const suggestions = await this.suggestAvailableUsernames(username);
+      return {
+        success: false,
+        message: usernameValidation.message,
+        suggestions,
+      };
     }
 
     const nameValidation = this.validateBusinessName(businessName);
@@ -417,12 +458,14 @@ class AuthService {
       return { success: false, message: pinValidation.message };
     }
 
-    const normalized = normalizeUsername(username);
+    const normalized = usernameValidation.normalized;
     const existingUser = await this.findShopByUsername(normalized);
     if (existingUser) {
+      const suggestions = await this.suggestAvailableUsernames(normalized);
       return {
         success: false,
         message: "Username already taken.",
+        suggestions,
       };
     }
 
@@ -463,9 +506,11 @@ class AuthService {
       });
     } catch (error) {
       if (error?.code === 11000) {
+        const suggestions = await this.suggestAvailableUsernames(normalized);
         return {
           success: false,
           message: "Username or channel is already registered.",
+          suggestions,
         };
       }
       throw error;
@@ -478,10 +523,21 @@ class AuthService {
       channelKey
     );
 
+    let recoveryCodes = [];
+    try {
+      const issued = await this.issueRecoveryCodesForShop(shop, {
+        revokeExisting: false,
+      });
+      recoveryCodes = issued.codes || [];
+    } catch (error) {
+      console.error("[AuthService] Recovery code issue on register:", error);
+    }
+
     return {
       success: true,
       sessionToken,
       shop: shop.toObject(),
+      recoveryCodes,
       message: "Registration complete.",
     };
   }
@@ -631,7 +687,8 @@ class AuthService {
   /** @deprecated Prefer loginWithCredentials / loginWithPinOnly */
   async login(usernameOrChannelKey, pin, channelCtx) {
     if (channelCtx?.channel) {
-      if (this.validateUsername(usernameOrChannelKey).valid) {
+      // Accept new + legacy usernames so grandfathered accounts still login.
+      if (isUsernameShaped(usernameOrChannelKey)) {
         return this.loginWithCredentials({
           username: usernameOrChannelKey,
           pin,
@@ -1092,6 +1149,136 @@ class AuthService {
     return { success: true, message: "Business description updated.", shop };
   }
 
+  /**
+   * Change login username (web + chat). Enforces the new registration policy.
+   * Sessions stay valid (keyed by shopId).
+   */
+  async updateUsernameForShop(shop, newUsername) {
+    if (shop?.isDemo) {
+      return {
+        success: false,
+        message: "Demo shops cannot change username.",
+      };
+    }
+
+    const validation = this.validateUsername(newUsername);
+    if (!validation.valid) {
+      const suggestions = await this.suggestAvailableUsernames(newUsername);
+      return {
+        success: false,
+        message: validation.message,
+        suggestions,
+      };
+    }
+
+    const normalized = validation.normalized;
+    if (normalized === normalizeUsername(shop.username)) {
+      return {
+        success: true,
+        message: "Username unchanged.",
+        shop,
+      };
+    }
+
+    const existing = await Shop.findOne({
+      _id: { $ne: shop._id },
+      username: normalized,
+    });
+    if (existing) {
+      const suggestions = await this.suggestAvailableUsernames(normalized);
+      return {
+        success: false,
+        message: "Username already taken.",
+        suggestions,
+      };
+    }
+
+    const previous = shop.username;
+    shop.username = normalized;
+    try {
+      await shop.save();
+    } catch (error) {
+      if (error?.code === 11000) {
+        const suggestions = await this.suggestAvailableUsernames(normalized);
+        return {
+          success: false,
+          message: "Username already taken.",
+          suggestions,
+        };
+      }
+      throw error;
+    }
+
+    return {
+      success: true,
+      message: `Username updated from @${previous} to @${normalized}.`,
+      shop,
+      previousUsername: previous,
+    };
+  }
+
+  async updateUsername(channel, channelKey, newUsername) {
+    try {
+      if (!(await this.isAuthenticated(channel, channelKey))) {
+        return {
+          success: false,
+          message:
+            "*Please login first*\n\nUse `login <username> <pin>` to access your account.",
+        };
+      }
+
+      const shop = await this.getAuthenticatedShop(channel, channelKey);
+      if (!shop) {
+        return { success: false, message: "*Profile not found*" };
+      }
+
+      if (shop.isDemo) {
+        return {
+          success: false,
+          message: "*Demo shops cannot change username.*",
+        };
+      }
+
+      const result = await this.updateUsernameForShop(shop, newUsername);
+      if (!result.success) {
+        const suggestionLines =
+          result.suggestions?.length > 0
+            ? "\n\n*Try:*\n" +
+              result.suggestions.map((s) => `• \`${s}\``).join("\n")
+            : "";
+        return {
+          success: false,
+          suggestions: result.suggestions,
+          message: `*${result.message}*${suggestionLines}`,
+        };
+      }
+
+      if (!result.previousUsername) {
+        return {
+          success: true,
+          shop: result.shop,
+          message: "*Username unchanged.*",
+        };
+      }
+
+      return {
+        success: true,
+        shop: result.shop,
+        message:
+          "*Username Updated!*\n\n" +
+          `Old: \`@${result.previousUsername}\`\n` +
+          `New: \`@${result.shop.username}\`\n\n` +
+          "Use the new username with your PIN on web, Telegram, and WhatsApp.",
+      };
+    } catch (error) {
+      console.error("[AuthService] Update username error:", error);
+      return {
+        success: false,
+        message: "Failed to update username. Please try again.",
+      };
+    }
+  }
+
   async getPinChangeStatus(channel, channelKey) {
     const session = await SessionStore.getPinChange(channel, channelKey);
     if (!session) return null;
@@ -1155,30 +1342,62 @@ class AuthService {
   // ==========================================
 
   validateUsername(username) {
-    const normalized = normalizeUsername(username);
-    if (!normalized) {
-      return { valid: false, message: "Username cannot be empty" };
-    }
-    if (normalized.length < 3) {
+    return validateUsernamePolicy(username);
+  }
+
+  async suggestAvailableUsernames(desired, count = 3) {
+    return suggestUsernames(
+      desired,
+      async (candidate) => Boolean(await this.findShopByUsername(candidate)),
+      count
+    );
+  }
+
+  /**
+   * Real-time availability check for registration UIs.
+   * @returns {{ available: boolean, username: string, valid: boolean, message?: string, suggestions?: string[] }}
+   */
+  async checkUsernameAvailability(usernameInput, { excludeShopId } = {}) {
+    const normalized = normalizeUsername(usernameInput);
+    const validation = this.validateUsername(usernameInput);
+
+    if (!validation.valid) {
+      const suggestions = await this.suggestAvailableUsernames(
+        normalized || usernameInput
+      );
       return {
+        available: false,
         valid: false,
-        message: "Username must be at least 3 characters",
+        username: normalized,
+        message: validation.message,
+        suggestions,
       };
     }
-    if (normalized.length > 32) {
+
+    const username = validation.normalized;
+    const existing = await this.findShopByUsername(username);
+    const isSelf =
+      existing &&
+      excludeShopId &&
+      String(existing._id) === String(excludeShopId);
+
+    if (existing && !isSelf) {
+      const suggestions = await this.suggestAvailableUsernames(username);
       return {
-        valid: false,
-        message: "Username must be at most 32 characters",
+        available: false,
+        valid: true,
+        username,
+        message: "Username already taken.",
+        suggestions,
       };
     }
-    if (!/^[a-z0-9_]+$/.test(normalized)) {
-      return {
-        valid: false,
-        message:
-          "Username may only contain lowercase letters, numbers, and underscores",
-      };
-    }
-    return { valid: true };
+
+    return {
+      available: true,
+      valid: true,
+      username,
+      suggestions: [],
+    };
   }
 
   validateBusinessName(name) {
@@ -1325,6 +1544,178 @@ class AuthService {
     if (hours < 24) return `${hours} hour${hours !== 1 ? "s" : ""} ago`;
     if (days < 7) return `${days} day${days !== 1 ? "s" : ""} ago`;
     return lastLogin.toLocaleDateString();
+  }
+
+  // ==========================================
+  // RECOVERY CODES
+  // ==========================================
+
+  formatRecoveryCodesMessage(codes) {
+    if (!codes?.length) {
+      return (
+        "*Recovery codes:* unavailable — generate them in Settings on the web.\n\n"
+      );
+    }
+    const list = codes.map((c) => `• \`${c}\``).join("\n");
+    return (
+      "*Save these recovery codes now*\n" +
+      "They are shown *once*. If you lose your PIN and these codes, the account may be unrecoverable.\n\n" +
+      `${list}\n\n` +
+      "_Screenshot and store them offline, then delete this message if you can._\n\n" +
+      "Reset later: `recover yourusername cs-xxxx-xxxx 1234`\n\n"
+    );
+  }
+
+  /**
+   * Issue a new recovery-code batch. Plaintext returned once; only hashes stored.
+   * @returns {{ success: boolean, codes?: string[], remaining?: number, message?: string }}
+   */
+  async issueRecoveryCodesForShop(shop, { revokeExisting = true } = {}) {
+    if (!shop?._id) {
+      return { success: false, message: "Shop required." };
+    }
+    if (shop.isDemo) {
+      return { success: false, message: "Demo shops cannot use recovery codes." };
+    }
+
+    if (revokeExisting) {
+      await RecoveryCode.updateMany(
+        { shopId: shop._id, usedAt: null, revokedAt: null },
+        { $set: { revokedAt: new Date() } }
+      );
+    }
+
+    const batchId = crypto.randomBytes(12).toString("hex");
+    const codes = generateRecoveryCodeBatch(RECOVERY_CODE_COUNT);
+    const docs = codes.map((plain) => ({
+      shopId: shop._id,
+      codeHash: hashRecoveryCode(plain),
+      batchId,
+      createdAt: new Date(),
+      usedAt: null,
+      revokedAt: null,
+    }));
+
+    await RecoveryCode.insertMany(docs);
+
+    return {
+      success: true,
+      codes,
+      remaining: codes.length,
+      batchId,
+      message: "Recovery codes generated. Save them now — they will not be shown again.",
+    };
+  }
+
+  async getRecoveryCodeStatus(shopId) {
+    if (!shopId) {
+      return { hasCodes: false, remaining: 0, totalUnused: 0 };
+    }
+    const remaining = await RecoveryCode.countDocuments({
+      shopId,
+      usedAt: null,
+      revokedAt: null,
+    });
+    const latest = await RecoveryCode.findOne({ shopId })
+      .sort({ createdAt: -1 })
+      .select("createdAt")
+      .lean();
+
+    return {
+      hasCodes: remaining > 0,
+      remaining,
+      lastIssuedAt: latest?.createdAt || null,
+    };
+  }
+
+  /**
+   * Redeem one recovery code to set a new PIN. Invalidates all sessions.
+   */
+  async redeemRecoveryCode({ username, code, newPin }) {
+    const normalizedUser = normalizeUsername(username);
+    const normalizedCode = normalizeRecoveryCode(code);
+
+    if (!normalizedUser || !normalizedCode) {
+      return {
+        success: false,
+        message: "username and recovery code are required.",
+      };
+    }
+
+    const pinValidation = this.validatePin(newPin);
+    if (!pinValidation.valid) {
+      return { success: false, message: pinValidation.message };
+    }
+
+    const shop = await this.findShopByUsername(normalizedUser);
+    if (!shop || shop.isActive === false) {
+      return {
+        success: false,
+        message: "Invalid username or recovery code.",
+      };
+    }
+
+    if (shop.isDemo) {
+      return {
+        success: false,
+        message: "Demo shops cannot recover with codes.",
+      };
+    }
+
+    const rateLimitCheck = await this.checkRateLimit(shop);
+    if (!rateLimitCheck.allowed) {
+      return {
+        success: false,
+        message: rateLimitCheck.message?.replace(/\*/g, "") || "Too many attempts. Try again later.",
+      };
+    }
+
+    const candidates = await RecoveryCode.find({
+      shopId: shop._id,
+      usedAt: null,
+      revokedAt: null,
+    });
+
+    const codeHash = hashRecoveryCode(normalizedCode);
+    let matched = null;
+    for (const row of candidates) {
+      if (recoveryCodesMatch(row.codeHash, codeHash)) {
+        matched = row;
+        break;
+      }
+    }
+
+    if (!matched) {
+      await this.recordFailedAttempt(shop);
+      return {
+        success: false,
+        message: "Invalid username or recovery code.",
+      };
+    }
+
+    matched.usedAt = new Date();
+    await matched.save();
+
+    shop.pin = await bcrypt.hash(String(newPin).trim(), 12);
+    await shop.resetLoginAttempts();
+
+    await SessionStore.deleteLoginSessionsByShopId(shop._id);
+
+    const remaining = await RecoveryCode.countDocuments({
+      shopId: shop._id,
+      usedAt: null,
+      revokedAt: null,
+    });
+
+    return {
+      success: true,
+      remaining,
+      mustRegenerate: remaining === 0,
+      message:
+        remaining > 0
+          ? `PIN reset. ${remaining} recovery code${remaining === 1 ? "" : "s"} left. Sign in with your new PIN. Consider regenerating codes in Settings.`
+          : "PIN reset. You have no recovery codes left — sign in and generate a new set in Settings.",
+    };
   }
 }
 

--- a/backend/services/commands/handlers/auth.js
+++ b/backend/services/commands/handlers/auth.js
@@ -30,14 +30,23 @@ export async function handleRegister(ctx, text) {
       });
 
       if (!result.success) {
-        return `*Registration failed*\n\n${result.message}`;
+        const suggestions =
+          result.suggestions?.length > 0
+            ? `\n\n*Try:*\n${result.suggestions.map((s) => `• \`${s}\``).join("\n")}`
+            : "";
+        return `*Registration failed*\n\n${result.message}${suggestions}`;
       }
+
+      const codesBlock = AuthService.formatRecoveryCodesMessage(
+        result.recoveryCodes
+      );
 
       return (
         `*Registration Complete!*\n\n` +
         `${businessName} is ready!\n\n` +
         `Username: \`${username.toLowerCase()}\`\n\n` +
         `Use the same username + PIN on web, Telegram, and WhatsApp.\n\n` +
+        codesBlock +
         `*Quick Start:*\n\n` +
         `*Add Products:*\n• add bread 2.50 stock 50\n• list - View products\n\n` +
         `*Record Sales:*\n• sell 2 bread 1 milk\n• daily - View report\n\n` +
@@ -66,11 +75,12 @@ export async function handleRegister(ctx, text) {
     return (
       `*Registration Format*\n\n` +
       `*Quick Registration:*\n` +
-      `\`register your_username "Business Name" 1234\`\n\n` +
+      `\`register yourusername "Business Name" 1234\`\n\n` +
+      `*Username rules:* 3–15 lowercase letters, optional digits at the end (e.g. musa, musa7).\n\n` +
       `*Or Progressive Registration:*\n` +
       `Just type: \`register\`\n\n` +
       `*Examples:*\n` +
-      `• \`register tinasales "Family Bakery" 5678\`\n` +
+      `• \`register musa "Family Bakery" 5678\`\n` +
       `• \`register\` (step-by-step)\n\n` +
       `Same username + PIN work on web, Telegram, and WhatsApp.`
     );
@@ -313,6 +323,36 @@ export async function handleProfileEditName(ctx, text) {
   }
 }
 
+export async function handleProfileEditUsername(ctx, text) {
+  const { channel, channelKey } = ctx;
+  try {
+    const match = text.match(
+      /(?:\/)?profile\s+edit\s+username\s+([a-zA-Z0-9_]{2,32})$/i
+    );
+
+    if (!match) {
+      return (
+        "*Invalid Format*\n\n" +
+        "Use: `profile edit username newusername`\n\n" +
+        "*Rules:* 3–15 lowercase letters, optional digits at the end.\n\n" +
+        "*Examples:*\n" +
+        "• `profile edit username musa`\n" +
+        "• `profile edit username musa7`"
+      );
+    }
+
+    const result = await AuthService.updateUsername(
+      channel,
+      channelKey,
+      match[1]
+    );
+    return result.message;
+  } catch (error) {
+    console.error("[CommandService] Edit username error:", error);
+    return "Failed to update username. Please try again.";
+  }
+}
+
 export async function handleProfileEditDescription(ctx, text) {
   const { channel, channelKey } = ctx;
   try {
@@ -352,5 +392,44 @@ export async function handleProfileEditPin(ctx) {
   } catch (error) {
     console.error("[CommandService] Edit PIN error:", error);
     return "Failed to start PIN change. Please try again.";
+  }
+}
+
+/**
+ * recover <username> <code> <newPin>
+ * @param {{ channel: string, channelKey: string }} ctx
+ */
+export async function handleRecover(ctx, text) {
+  try {
+    const match = text.match(
+      /^recover\s+(\S+)\s+(\S+)\s+(\d{4})$/i
+    );
+    if (!match) {
+      return (
+        "*Recover account*\n\n" +
+        "Reset your PIN with a one-time recovery code:\n\n" +
+        "`recover yourusername cs-xxxx-xxxx 1234`\n\n" +
+        "Codes were shown once at signup (or in Settings). " +
+        "Losing your PIN and all codes may lock you out permanently."
+      );
+    }
+
+    const result = await AuthService.redeemRecoveryCode({
+      username: match[1],
+      code: match[2],
+      newPin: match[3],
+    });
+
+    if (!result.success) {
+      return `*Recovery failed*\n\n${result.message}`;
+    }
+
+    return (
+      `*PIN reset*\n\n${result.message}\n\n` +
+      `Sign in: \`login ${match[1].toLowerCase()} ${match[3]}\``
+    );
+  } catch (error) {
+    console.error("[CommandService] Recover error:", error);
+    return "Recovery failed. Please try again.";
   }
 }

--- a/backend/services/commands/handlers/help.js
+++ b/backend/services/commands/handlers/help.js
@@ -9,6 +9,7 @@ export function getHelpText() {
 • register your_username "Business Name" 1234 - Quick setup
 • login your_username 1234 - Login (links this chat on first use)
 • login 1234 - PIN-only (only after this chat is linked)
+• recover yourusername cs-xxxx-xxxx 1234 - Reset PIN with a recovery code
 • logout - End this channel's session
 • account - View account info
 • status - Check registration/login status
@@ -22,6 +23,7 @@ View:
 
 Edit:
 • profile edit name "New Name" - Change business name
+• profile edit username newusername - Change login username
 • profile edit description "New Desc" - Update description
 • profile edit pin - Change PIN (secure 2-step)
 

--- a/backend/services/commands/router.js
+++ b/backend/services/commands/router.js
@@ -8,8 +8,10 @@ import {
   handleAccount,
   handleStatus,
   handleProfileEditName,
+  handleProfileEditUsername,
   handleProfileEditDescription,
   handleProfileEditPin,
+  handleRecover,
 } from "./handlers/auth.js";
 
 import {
@@ -104,6 +106,10 @@ async function processCommand(actorId, text, channelHint) {
     return await handleLogin(ctx, text);
   }
 
+  if (command.startsWith("recover") || command === "recover") {
+    return await handleRecover(ctx, text);
+  }
+
   // Bare PIN while a linked chat is waiting after "login" prompt
   if (
     /^\d{4}$/.test(command) &&
@@ -134,6 +140,13 @@ async function processCommand(actorId, text, channelHint) {
     command.startsWith("profile edit name")
   ) {
     return await handleProfileEditName(ctx, text);
+  }
+
+  if (
+    command.startsWith("/profile edit username") ||
+    command.startsWith("profile edit username")
+  ) {
+    return await handleProfileEditUsername(ctx, text);
   }
 
   if (

--- a/backend/services/sessionStore.js
+++ b/backend/services/sessionStore.js
@@ -95,6 +95,12 @@ class SessionStore {
     await AuthSession.deleteOne({ type: "session", sessionToken });
   }
 
+  /** End every login session for a shop (e.g. after PIN recovery). */
+  async deleteLoginSessionsByShopId(shopId) {
+    if (!shopId) return;
+    await AuthSession.deleteMany({ type: "session", shopId });
+  }
+
   async upsertRegistration(channel, channelKey, { step, data, startTime }) {
     const started =
       startTime instanceof Date

--- a/backend/tests/api.v1.test.js
+++ b/backend/tests/api.v1.test.js
@@ -300,7 +300,7 @@ describe("API v1", () => {
   });
 
   it("registers a new shop via API", async () => {
-    const newUsername = `api_reg_${Date.now().toString(36)}`;
+    const newUsername = `apireg${Date.now().toString().slice(-6)}`.slice(0, 15);
     const reg = await request(server, {
       method: "POST",
       path: "/api/v1/auth/register",
@@ -318,6 +318,156 @@ describe("API v1", () => {
     );
     assert.ok(reg.body.token);
     assert.equal(reg.body.shop.username, newUsername);
+
+    await wipeShopData({
+      shopId: reg.body.shop.id,
+      username: newUsername,
+    });
+  });
+
+  it("checks username availability and rejects reserved names", async () => {
+    const taken = await request(server, {
+      method: "GET",
+      path: `/api/v1/auth/username?username=${encodeURIComponent(username)}`,
+    });
+    assert.equal(taken.status, 200);
+    assert.equal(taken.body.available, false);
+    assert.ok(Array.isArray(taken.body.suggestions));
+    assert.ok(taken.body.suggestions.length >= 1);
+
+    const reserved = await request(server, {
+      method: "GET",
+      path: "/api/v1/auth/username?username=admin",
+    });
+    assert.equal(reserved.status, 200);
+    assert.equal(reserved.body.available, false);
+    assert.equal(reserved.body.valid, false);
+    assert.ok(Array.isArray(reserved.body.suggestions));
+    assert.ok(reserved.body.suggestions.length >= 1);
+    assert.ok(reserved.body.suggestions.every((s) => s !== "admin"));
+
+    const okName = `ok${Date.now().toString().slice(-8)}`.slice(0, 15);
+    const free = await request(server, {
+      method: "GET",
+      path: `/api/v1/auth/username?username=${encodeURIComponent(okName)}`,
+    });
+    assert.equal(free.status, 200);
+    assert.equal(free.body.available, true);
+    assert.equal(free.body.username, okName);
+  });
+
+  it("changes username via profile API", async () => {
+    const login = await request(server, {
+      method: "POST",
+      path: "/api/v1/auth/login",
+      body: { username, pin },
+    });
+    assert.equal(login.status, 200);
+    const token = login.body.token;
+
+    const selfCheck = await request(server, {
+      method: "GET",
+      path: `/api/v1/auth/username?username=${encodeURIComponent(username)}`,
+      token,
+    });
+    assert.equal(selfCheck.status, 200);
+    assert.equal(selfCheck.body.available, true);
+
+    const next = `ren${Date.now().toString().slice(-8)}`.slice(0, 15);
+    const changed = await request(server, {
+      method: "PATCH",
+      path: "/api/v1/auth/profile/username",
+      token,
+      body: { username: next },
+    });
+    assert.equal(
+      changed.status,
+      200,
+      `username change failed: ${JSON.stringify(changed.body)}`
+    );
+    assert.equal(changed.body.shop.username, next);
+
+    const oldLogin = await request(server, {
+      method: "POST",
+      path: "/api/v1/auth/login",
+      body: { username, pin },
+    });
+    assert.equal(oldLogin.status, 401);
+
+    const newLogin = await request(server, {
+      method: "POST",
+      path: "/api/v1/auth/login",
+      body: { username: next, pin },
+    });
+    assert.equal(newLogin.status, 200);
+    assert.equal(newLogin.body.shop.username, next);
+
+    // afterEach wipe uses this username
+    username = next;
+  });
+
+  it("issues recovery codes on register and redeems one to reset PIN", async () => {
+    const newUsername = `recv${Date.now().toString().slice(-8)}`.slice(0, 15);
+    const reg = await request(server, {
+      method: "POST",
+      path: "/api/v1/auth/register",
+      body: {
+        username: newUsername,
+        businessName: `Recv Shop ${Date.now()}`,
+        pin: "4829",
+        businessDescription: "General merchandise for recovery test",
+      },
+    });
+    assert.equal(reg.status, 201, JSON.stringify(reg.body));
+    assert.ok(Array.isArray(reg.body.recoveryCodes));
+    assert.equal(reg.body.recoveryCodes.length, 8);
+    const token = reg.body.token;
+    const code = reg.body.recoveryCodes[0];
+
+    const status = await request(server, {
+      method: "GET",
+      path: "/api/v1/auth/recovery",
+      token,
+    });
+    assert.equal(status.status, 200);
+    assert.equal(status.body.remaining, 8);
+
+    const redeem = await request(server, {
+      method: "POST",
+      path: "/api/v1/auth/recovery/redeem",
+      body: {
+        username: newUsername,
+        code,
+        newPin: "5731",
+      },
+    });
+    assert.equal(redeem.status, 200, JSON.stringify(redeem.body));
+    assert.equal(redeem.body.remaining, 7);
+
+    const reuse = await request(server, {
+      method: "POST",
+      path: "/api/v1/auth/recovery/redeem",
+      body: {
+        username: newUsername,
+        code,
+        newPin: "5820",
+      },
+    });
+    assert.equal(reuse.status, 401);
+
+    const oldLogin = await request(server, {
+      method: "POST",
+      path: "/api/v1/auth/login",
+      body: { username: newUsername, pin: "4829" },
+    });
+    assert.equal(oldLogin.status, 401);
+
+    const newLogin = await request(server, {
+      method: "POST",
+      path: "/api/v1/auth/login",
+      body: { username: newUsername, pin: "5731" },
+    });
+    assert.equal(newLogin.status, 200);
 
     await wipeShopData({
       shopId: reg.body.shop.id,

--- a/backend/tests/helpers/fixtures.js
+++ b/backend/tests/helpers/fixtures.js
@@ -8,10 +8,20 @@ let counter = 0;
 
 export function uniqueUsername(prefix = "shop") {
   counter += 1;
+  const letters = String(prefix)
+    .toLowerCase()
+    .replace(/[^a-z]/g, "")
+    .slice(0, 8) || "shop";
   const suffix = `${Date.now().toString(36)}${counter}${crypto
     .randomBytes(2)
-    .toString("hex")}`;
-  return `${prefix}_${suffix}`.slice(0, 32).toLowerCase();
+    .toString("hex")}`
+    .replace(/[^a-z0-9]/g, "");
+  // New policy: letters then trailing digits, max 15. Digits-only suffix keeps it valid.
+  const digits = suffix.replace(/[^0-9]/g, "").slice(-6) || String(counter);
+  return `${letters.slice(0, 15 - Math.min(digits.length, 6))}${digits}`.slice(
+    0,
+    15
+  );
 }
 
 /** @deprecated Use uniqueUsername — kept for older test call sites. */
@@ -68,6 +78,7 @@ export async function createTestShop(overrides = {}) {
 }
 
 function normalizeOverrideUsername(value) {
+  // Tests may still create grandfathered shops with underscores via Shop.create.
   if (value && /^[a-z0-9_]{3,32}$/i.test(String(value))) {
     return String(value).toLowerCase();
   }

--- a/backend/tests/helpers/mongo.js
+++ b/backend/tests/helpers/mongo.js
@@ -23,7 +23,12 @@ export async function dropLegacyAuthIndexes() {
   // Ensure new schema indexes exist
   const Shop = (await import("../../models/Shop.js")).default;
   const AuthSession = (await import("../../models/AuthSession.js")).default;
-  await Promise.all([Shop.syncIndexes(), AuthSession.syncIndexes()]);
+  const RecoveryCode = (await import("../../models/RecoveryCode.js")).default;
+  await Promise.all([
+    Shop.syncIndexes(),
+    AuthSession.syncIndexes(),
+    RecoveryCode.syncIndexes(),
+  ]);
 }
 
 export async function connectTestDb() {
@@ -58,6 +63,7 @@ export async function wipeShopData({
   const Shop = (await import("../../models/Shop.js")).default;
   const Expense = (await import("../../models/Expense.js")).default;
   const AuthSession = (await import("../../models/AuthSession.js")).default;
+  const RecoveryCode = (await import("../../models/RecoveryCode.js")).default;
 
   if (shopId) {
     await Promise.all([
@@ -66,6 +72,7 @@ export async function wipeShopData({
       Customer.deleteMany({ shopId }),
       Expense.deleteMany({ shopId }),
       AuthSession.deleteMany({ shopId }),
+      RecoveryCode.deleteMany({ shopId }),
       Shop.deleteOne({ _id: shopId }),
     ]);
   }

--- a/backend/tests/recoveryCodes.test.js
+++ b/backend/tests/recoveryCodes.test.js
@@ -1,0 +1,36 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  generateRecoveryCodeBatch,
+  generateRecoveryCodePlaintext,
+  hashRecoveryCode,
+  normalizeRecoveryCode,
+  recoveryCodesMatch,
+  RECOVERY_CODE_COUNT,
+} from "../utils/recoveryCodes.js";
+
+describe("recoveryCodes util", () => {
+  it("formats and normalizes codes", () => {
+    const plain = generateRecoveryCodePlaintext();
+    assert.match(plain, /^cs-[a-z0-9]{4}-[a-z0-9]{4}$/);
+    assert.equal(
+      normalizeRecoveryCode("CS-A3K9-M2PQ"),
+      normalizeRecoveryCode("cs a3k9 m2pq")
+    );
+  });
+
+  it("hashes consistently and matches timing-safe", () => {
+    const a = hashRecoveryCode("cs-test-code");
+    const b = hashRecoveryCode("CS-TEST-CODE");
+    assert.ok(a);
+    assert.equal(a, b);
+    assert.equal(recoveryCodesMatch(a, b), true);
+    assert.equal(recoveryCodesMatch(a, hashRecoveryCode("cs-other-code")), false);
+  });
+
+  it("generates a unique batch", () => {
+    const batch = generateRecoveryCodeBatch(RECOVERY_CODE_COUNT);
+    assert.equal(batch.length, RECOVERY_CODE_COUNT);
+    assert.equal(new Set(batch.map(normalizeRecoveryCode)).size, batch.length);
+  });
+});

--- a/backend/tests/usernamePolicy.test.js
+++ b/backend/tests/usernamePolicy.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  validateUsername,
+  isUsernameShaped,
+  isReservedUsername,
+  suggestUsernames,
+  USERNAME_PATTERN,
+} from "../utils/usernamePolicy.js";
+
+describe("usernamePolicy", () => {
+  it("accepts valid usernames and normalizes case", () => {
+    const result = validateUsername("Musa");
+    assert.equal(result.valid, true);
+    assert.equal(result.normalized, "musa");
+    assert.equal(validateUsername("musa7").valid, true);
+    assert.equal(validateUsername("devking").valid, true);
+    assert.equal(validateUsername("chartshop1").valid, true);
+  });
+
+  it("rejects invalid shapes", () => {
+    assert.equal(validateUsername("mu").valid, false);
+    assert.equal(validateUsername("musa_7").valid, false);
+    assert.equal(validateUsername("musa.shop").valid, false);
+    assert.equal(validateUsername("7musa").valid, false);
+    assert.equal(validateUsername("mu7sa").valid, false);
+    assert.equal(validateUsername("verylongusername123").valid, false);
+    assert.equal(USERNAME_PATTERN.test("verylongusername123"), false);
+  });
+
+  it("blocks reserved names exactly", () => {
+    assert.equal(isReservedUsername("admin"), true);
+    assert.equal(isReservedUsername("ChartShop"), true);
+    assert.equal(validateUsername("support").valid, false);
+    assert.equal(validateUsername("system").valid, false);
+    assert.equal(validateUsername("chartshop").valid, false);
+    assert.equal(validateUsername("chartshop1").valid, true);
+  });
+
+  it("recognizes legacy shapes for login routing only", () => {
+    assert.equal(isUsernameShaped("boutique_demo"), true);
+    assert.equal(isUsernameShaped("musa"), true);
+    assert.equal(validateUsername("boutique_demo").valid, false);
+  });
+
+  it("suggests digit-suffix alternatives", async () => {
+    const taken = new Set(["musa", "musa1"]);
+    const suggestions = await suggestUsernames(
+      "musa",
+      async (c) => taken.has(c),
+      3
+    );
+    assert.deepEqual(suggestions, ["musa2", "musa3", "musa4"]);
+  });
+});

--- a/backend/utils/recoveryCodes.js
+++ b/backend/utils/recoveryCodes.js
@@ -1,0 +1,79 @@
+/**
+ * Recovery codes: generate once, show once, store hashes only, single-use.
+ * Format: cs-xxxx-xxxx (readable). Normalize before hash/compare.
+ */
+
+import crypto from "crypto";
+
+export const RECOVERY_CODE_COUNT = 8;
+
+/** Unambiguous alphabet (no 0/o, 1/i/l). */
+const ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz";
+
+function pepper() {
+  return (
+    process.env.RECOVERY_CODE_PEPPER ||
+    process.env.SESSION_SECRET ||
+    "chartshop-recovery-v1"
+  );
+}
+
+function randomSegment(length) {
+  const bytes = crypto.randomBytes(length);
+  let out = "";
+  for (let i = 0; i < length; i += 1) {
+    out += ALPHABET[bytes[i] % ALPHABET.length];
+  }
+  return out;
+}
+
+/** Plaintext display form, e.g. cs-a3k9-m2pq */
+export function generateRecoveryCodePlaintext() {
+  return `cs-${randomSegment(4)}-${randomSegment(4)}`;
+}
+
+/**
+ * Strip spaces/dashes/case for verification.
+ * "CS-A3K9-M2PQ" / "cs a3k9 m2pq" → "csa3k9m2pq"
+ */
+export function normalizeRecoveryCode(code) {
+  return String(code || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+export function hashRecoveryCode(code) {
+  const normalized = normalizeRecoveryCode(code);
+  if (!normalized) return null;
+  return crypto
+    .createHmac("sha256", pepper())
+    .update(normalized)
+    .digest("hex");
+}
+
+export function recoveryCodesMatch(aHash, bHash) {
+  if (!aHash || !bHash) return false;
+  const a = Buffer.from(String(aHash), "utf8");
+  const b = Buffer.from(String(bHash), "utf8");
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+/** Generate N plaintext codes (unique within the batch). */
+export function generateRecoveryCodeBatch(count = RECOVERY_CODE_COUNT) {
+  const codes = [];
+  const seen = new Set();
+  let guard = 0;
+  while (codes.length < count && guard < count * 20) {
+    guard += 1;
+    const plain = generateRecoveryCodePlaintext();
+    const key = normalizeRecoveryCode(plain);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    codes.push(plain);
+  }
+  if (codes.length < count) {
+    throw new Error("Failed to generate unique recovery codes");
+  }
+  return codes;
+}

--- a/backend/utils/usernamePolicy.js
+++ b/backend/utils/usernamePolicy.js
@@ -1,0 +1,130 @@
+/**
+ * ChartShop username policy (new registrations).
+ *
+ * - Lowercase letters; optional digits only at the end
+ * - No spaces, underscores, dots, or special characters
+ * - Length 3–15
+ * - Case-insensitive uniqueness (normalize: trim + lowercase)
+ * - Exact reserved-word blocklist
+ *
+ * Existing shops may still use legacy usernames (underscores, up to 32 chars).
+ * Login accepts both shapes; only registration enforces this policy.
+ */
+
+import { normalizeUsername } from "./channelIdentity.js";
+
+export const USERNAME_MIN = 3;
+export const USERNAME_MAX = 15;
+
+/** New registration format: letters, then optional trailing digits. */
+export const USERNAME_PATTERN = /^(?=.{3,15}$)[a-z]+[0-9]*$/;
+
+/** Grandfathered / demo accounts may still use this shape. */
+export const LEGACY_USERNAME_PATTERN = /^[a-z0-9_]{3,32}$/;
+
+export const RESERVED_USERNAMES = Object.freeze([
+  "admin",
+  "support",
+  "system",
+  "chartshop",
+]);
+
+const RESERVED_SET = new Set(RESERVED_USERNAMES);
+
+export function isReservedUsername(username) {
+  const normalized = normalizeUsername(username);
+  return Boolean(normalized) && RESERVED_SET.has(normalized);
+}
+
+/** True if the string looks like a login username (new or legacy). */
+export function isUsernameShaped(username) {
+  const normalized = normalizeUsername(username);
+  if (!normalized) return false;
+  return (
+    USERNAME_PATTERN.test(normalized) ||
+    LEGACY_USERNAME_PATTERN.test(normalized)
+  );
+}
+
+/**
+ * Validate a username for new registration.
+ * @returns {{ valid: boolean, message?: string, normalized?: string }}
+ */
+export function validateUsername(username) {
+  const normalized = normalizeUsername(username);
+
+  if (!normalized) {
+    return { valid: false, message: "Username cannot be empty" };
+  }
+  if (normalized.length < USERNAME_MIN) {
+    return {
+      valid: false,
+      message: `Username must be at least ${USERNAME_MIN} characters`,
+    };
+  }
+  if (normalized.length > USERNAME_MAX) {
+    return {
+      valid: false,
+      message: `Username must be at most ${USERNAME_MAX} characters`,
+    };
+  }
+  if (!USERNAME_PATTERN.test(normalized)) {
+    return {
+      valid: false,
+      message:
+        "Username must be lowercase letters only, with optional digits at the end (no spaces, underscores, or symbols)",
+    };
+  }
+  if (isReservedUsername(normalized)) {
+    return {
+      valid: false,
+      message: `"${normalized}" is reserved. Please choose a different username`,
+    };
+  }
+
+  return { valid: true, normalized };
+}
+
+/** Letter prefix used when suggesting alternatives (strip trailing digits). */
+export function usernameLetterRoot(username) {
+  const normalized = normalizeUsername(username);
+  const root = normalized.replace(/[0-9]+$/, "").replace(/[^a-z]/g, "");
+  if (root.length >= 2) return root.slice(0, USERNAME_MAX - 1);
+  if (root.length === 1) return `${root}u`.slice(0, USERNAME_MAX - 1);
+  return "shop";
+}
+
+/**
+ * Build candidate alternatives like musa1, musa2, …
+ * @param {string} desired
+ * @param {(candidate: string) => boolean | Promise<boolean>} isUnavailable
+ * @param {number} [count=3]
+ * @returns {Promise<string[]>}
+ */
+export async function suggestUsernames(desired, isUnavailable, count = 3) {
+  const root = usernameLetterRoot(desired);
+  const suggestions = [];
+  let n = 1;
+
+  while (suggestions.length < count && n < 1000) {
+    const suffix = String(n);
+    const maxLetters = USERNAME_MAX - suffix.length;
+    if (maxLetters < 2) break;
+
+    const candidate = `${root.slice(0, maxLetters)}${suffix}`;
+    n += 1;
+
+    if (!USERNAME_PATTERN.test(candidate)) continue;
+    if (isReservedUsername(candidate)) continue;
+    if (candidate === normalizeUsername(desired)) continue;
+
+    // eslint-disable-next-line no-await-in-loop
+    if (await isUnavailable(candidate)) continue;
+
+    suggestions.push(candidate);
+  }
+
+  return suggestions;
+}
+
+export { normalizeUsername };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { DemoTourProvider } from '@/components/demo/DemoTour';
 import { HomePage } from '@/pages/HomePage';
 import { LoginPage } from '@/pages/LoginPage';
 import { RegisterPage } from '@/pages/RegisterPage';
+import { RecoverPage } from '@/pages/RecoverPage';
 import { ChatPage } from '@/pages/ChatPage';
 import { ActivityPage } from '@/pages/ActivityPage';
 import { DashboardPage } from '@/pages/DashboardPage';
@@ -28,6 +29,7 @@ export function App() {
               <Route index element={<HomePage />} />
               <Route path="login" element={<LoginPage />} />
               <Route path="register" element={<RegisterPage />} />
+              <Route path="recover" element={<RecoverPage />} />
             </Route>
 
             <Route path="app" element={<ProtectedRoute />}>

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -118,10 +118,125 @@ export async function register(input: RegisterInput): Promise<LoginResponse> {
     return data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
+      const payload = error.response?.data as
+        | { error?: string; suggestions?: string[] }
+        | undefined;
+      const message = payload?.error || 'Registration failed';
+      return {
+        success: false,
+        token: '',
+        shop: null as unknown as Shop,
+        error: message,
+        suggestions: payload?.suggestions,
+      };
+    }
+    throw error;
+  }
+}
+
+export type UsernameCheckResult = {
+  success: boolean;
+  available: boolean;
+  valid: boolean;
+  username: string;
+  message?: string;
+  suggestions?: string[];
+  error?: string;
+};
+
+export async function checkUsername(
+  username: string,
+): Promise<UsernameCheckResult> {
+  try {
+    const { data } = await api.get<UsernameCheckResult>('/auth/username', {
+      params: { username },
+    });
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
       const message =
         (error.response?.data as { error?: string } | undefined)?.error ||
-        'Registration failed';
-      return { success: false, token: '', shop: null as unknown as Shop, error: message };
+        'Could not check username';
+      return {
+        success: false,
+        available: false,
+        valid: false,
+        username,
+        error: message,
+      };
+    }
+    throw error;
+  }
+}
+
+export type RedeemRecoveryInput = {
+  username: string;
+  code: string;
+  newPin: string;
+};
+
+export type RedeemRecoveryResult = {
+  success: boolean;
+  message?: string;
+  remaining?: number;
+  mustRegenerate?: boolean;
+  error?: string;
+};
+
+export async function redeemRecovery(
+  input: RedeemRecoveryInput,
+): Promise<RedeemRecoveryResult> {
+  try {
+    const { data } = await api.post<RedeemRecoveryResult>(
+      '/auth/recovery/redeem',
+      input,
+    );
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const message =
+        (error.response?.data as { error?: string } | undefined)?.error ||
+        'Recovery failed';
+      return { success: false, error: message };
+    }
+    throw error;
+  }
+}
+
+export type RecoveryStatus = {
+  success: boolean;
+  hasCodes: boolean;
+  remaining: number;
+  lastIssuedAt?: string | null;
+  error?: string;
+};
+
+export async function fetchRecoveryStatus(): Promise<RecoveryStatus> {
+  const { data } = await api.get<RecoveryStatus>('/auth/recovery');
+  return data;
+}
+
+export async function regenerateRecoveryCodes(): Promise<{
+  success: boolean;
+  recoveryCodes?: string[];
+  remaining?: number;
+  message?: string;
+  error?: string;
+}> {
+  try {
+    const { data } = await api.post<{
+      success: boolean;
+      recoveryCodes?: string[];
+      remaining?: number;
+      message?: string;
+    }>('/auth/recovery/regenerate');
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const message =
+        (error.response?.data as { error?: string } | undefined)?.error ||
+        'Could not regenerate codes';
+      return { success: false, error: message };
     }
     throw error;
   }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -44,7 +44,8 @@ api.interceptors.response.use(
         const isPublic =
           path === '/' ||
           path.startsWith('/login') ||
-          path.startsWith('/register');
+          path.startsWith('/register') ||
+          path.startsWith('/recover');
         if (!isPublic) {
           window.location.assign('/login');
         }
@@ -75,4 +76,6 @@ export type LoginResponse = {
   token: string;
   shop: Shop;
   error?: string;
+  suggestions?: string[];
+  recoveryCodes?: string[];
 };

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -135,3 +135,14 @@ export async function updateProfilePin(oldPin: string, newPin: string) {
   const { data } = await api.patch('/auth/profile/pin', { oldPin, newPin });
   return data;
 }
+
+export async function updateProfileUsername(username: string) {
+  const { data } = await api.patch<{
+    success: boolean;
+    shop: Shop;
+    message?: string;
+    error?: string;
+    suggestions?: string[];
+  }>('/auth/profile/username', { username });
+  return data;
+}

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -54,13 +54,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [applySession],
   );
 
-  const register = useCallback(
-    async (input: RegisterInput) => {
-      const result = await registerRequest(input);
-      if (!result.success || !result.token) {
-        throw new Error(result.error || 'Registration failed');
+  const register = useCallback(async (input: RegisterInput) => {
+    const result = await registerRequest(input);
+    if (!result.success || !result.token) {
+      const err = new Error(result.error || 'Registration failed') as Error & {
+        suggestions?: string[];
+      };
+      if (result.suggestions?.length) {
+        err.suggestions = result.suggestions;
       }
-      applySession(result.token, result.shop);
+      throw err;
+    }
+    // Defer session until the caller finishes the recovery-codes step.
+    return {
+      recoveryCodes: result.recoveryCodes || [],
+      token: result.token,
+      shop: result.shop,
+    };
+  }, []);
+
+  const establishSession = useCallback(
+    (nextToken: string, nextShop: Shop) => {
+      applySession(nextToken, nextShop);
     },
     [applySession],
   );
@@ -100,11 +115,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isDemo: Boolean(shop?.isDemo),
       login,
       register,
+      establishSession,
       enterDemo,
       logout,
       updateShop,
     }),
-    [token, shop, login, register, enterDemo, logout, updateShop],
+    [
+      token,
+      shop,
+      login,
+      register,
+      establishSession,
+      enterDemo,
+      logout,
+      updateShop,
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/auth/auth-context.ts
+++ b/frontend/src/auth/auth-context.ts
@@ -8,7 +8,13 @@ export type AuthState = {
   isAuthenticated: boolean;
   isDemo: boolean;
   login: (username: string, pin: string) => Promise<void>;
-  register: (input: RegisterInput) => Promise<void>;
+  /** Registers without opening a session — caller must call establishSession. */
+  register: (input: RegisterInput) => Promise<{
+    recoveryCodes: string[];
+    token: string;
+    shop: Shop;
+  }>;
+  establishSession: (token: string, shop: Shop) => void;
   enterDemo: (sector?: string) => Promise<void>;
   logout: () => Promise<void>;
   updateShop: (patch: Partial<Shop>) => void;

--- a/frontend/src/components/auth/RecoveryCodesPanel.tsx
+++ b/frontend/src/components/auth/RecoveryCodesPanel.tsx
@@ -1,0 +1,227 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { Button } from '@/components/ui/Button';
+import { ArrowButton } from '@/components/marketing/marketingPrimitives';
+
+const Panel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+`;
+
+const Warning = styled.p`
+  margin: 0;
+  padding: 12px 14px;
+  background: ${({ theme }) => theme.colors.dangerTint};
+  color: ${({ theme }) => theme.colors.danger};
+  font-size: 0.9rem;
+  line-height: 1.5;
+`;
+
+const Lead = styled.p`
+  margin: 0;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: 0.92rem;
+  line-height: 1.5;
+`;
+
+const CodeList = styled.ul`
+  margin: 0;
+  padding: 12px 14px;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+  background: ${({ theme }) => theme.colors.cream};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.95rem;
+`;
+
+const CodeItem = styled.li`
+  color: ${({ theme }) => theme.colors.textPrimary};
+  letter-spacing: 0.02em;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+`;
+
+const Confirm = styled.label`
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: ${({ theme }) => theme.colors.textPrimary};
+  cursor: pointer;
+
+  input {
+    margin-top: 3px;
+    flex-shrink: 0;
+  }
+`;
+
+const Status = styled.p`
+  margin: 0;
+  font-size: 0.82rem;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+function buildShareText(codes: string[], username?: string | null) {
+  const who = username ? ` for @${username}` : '';
+  return [
+    `ChartShop recovery codes${who}`,
+    'Keep private. Each code resets your PIN once.',
+    'Anyone with this chat can reset your shop PIN.',
+    '',
+    ...codes,
+    '',
+    'Reset: open ChartShop → /recover',
+  ].join('\n');
+}
+
+function openWhatsAppShare(text: string) {
+  const url = `https://wa.me/?text=${encodeURIComponent(text)}`;
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+type RecoveryCodesPanelProps = {
+  codes: string[];
+  username?: string | null;
+  onContinue?: () => void;
+  continueLabel?: string;
+  requireAck?: boolean;
+};
+
+export function RecoveryCodesPanel({
+  codes,
+  username,
+  onContinue,
+  continueLabel = 'I saved my codes — continue',
+  requireAck = true,
+}: RecoveryCodesPanelProps) {
+  const [copied, setCopied] = useState(false);
+  const [shared, setShared] = useState(false);
+  const [acked, setAcked] = useState(!requireAck);
+
+  async function copyAll() {
+    try {
+      await navigator.clipboard.writeText(codes.join('\n'));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  function downloadTxt() {
+    const blob = new Blob([buildShareText(codes, username), '\n'], {
+      type: 'text/plain;charset=utf-8',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'chartshop-recovery-codes.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function shareToWhatsApp() {
+    const text = buildShareText(codes, username);
+    try {
+      if (
+        typeof navigator !== 'undefined' &&
+        typeof navigator.share === 'function'
+      ) {
+        await navigator.share({
+          title: 'ChartShop recovery codes',
+          text,
+        });
+        setShared(true);
+        window.setTimeout(() => setShared(false), 2500);
+        return;
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return;
+      }
+    }
+
+    openWhatsAppShare(text);
+    setShared(true);
+    window.setTimeout(() => setShared(false), 2500);
+  }
+
+  return (
+    <Panel>
+      <Warning>
+        Save these codes now. They are shown once and never again. If you lose
+        your PIN and these codes, your shop may be unrecoverable.
+      </Warning>
+      <Lead>
+        Use one code with your username at <strong>/recover</strong> to reset
+        your PIN. Each code works only once.
+      </Lead>
+      <CodeList>
+        {codes.map((code) => (
+          <CodeItem key={code}>{code}</CodeItem>
+        ))}
+      </CodeList>
+      <Actions>
+        <Button
+          type="button"
+          variant="light"
+          size="sm"
+          onClick={() => void copyAll()}
+        >
+          {copied ? 'Copied' : 'Copy all'}
+        </Button>
+        <Button type="button" variant="light" size="sm" onClick={downloadTxt}>
+          Download .txt
+        </Button>
+        <Button
+          type="button"
+          variant="light"
+          size="sm"
+          onClick={() => void shareToWhatsApp()}
+        >
+          {shared ? 'Opened share' : 'Share to WhatsApp'}
+        </Button>
+      </Actions>
+      <Status>
+        Tip: in WhatsApp, choose <strong>You</strong> (Message yourself) so the
+        codes stay in your personal notes. Anyone with that chat can reset your
+        PIN.
+      </Status>
+      {onContinue ? (
+        <>
+          {requireAck ? (
+            <Confirm>
+              <input
+                type="checkbox"
+                checked={acked}
+                onChange={(e) => setAcked(e.target.checked)}
+              />
+              <span>
+                I saved these codes offline. I understand ChartShop cannot show
+                them again.
+              </span>
+            </Confirm>
+          ) : null}
+          <Actions>
+            <ArrowButton type="button" disabled={!acked} onClick={onContinue}>
+              {continueLabel}
+            </ArrowButton>
+          </Actions>
+        </>
+      ) : null}
+      <Status>
+        ChartShop never sends codes to WhatsApp for you — this only opens a
+        share on your device.
+      </Status>
+    </Panel>
+  );
+}

--- a/frontend/src/components/marketing/AuthShell.tsx
+++ b/frontend/src/components/marketing/AuthShell.tsx
@@ -83,8 +83,11 @@ const Form = styled.form`
   gap: ${({ theme }) => theme.space[4]};
 `;
 
-const FooterNote = styled.p`
+const FooterNote = styled.div`
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   font-size: 0.92rem;
   color: ${({ theme }) => theme.colors.textSecondary};
 
@@ -228,10 +231,10 @@ type AuthShellProps = {
   showcaseTitle: string;
   showcaseLead: string;
   preview: Array<{ label: string; value: string }>;
-  footer: ReactNode;
-  onSubmit: (event: FormEvent) => void;
+  footer?: ReactNode;
+  onSubmit?: (event: FormEvent) => void;
   children: ReactNode;
-  actions: ReactNode;
+  actions?: ReactNode;
 };
 
 export function AuthShell({
@@ -241,10 +244,10 @@ export function AuthShell({
   showcaseTitle,
   showcaseLead,
   preview,
-  footer,
+  footer = null,
   onSubmit,
   children,
-  actions,
+  actions = null,
 }: AuthShellProps) {
   return (
     <Page>
@@ -262,11 +265,16 @@ export function AuthShell({
             </div>
             <Lead>{lead}</Lead>
           </Intro>
-          <Form onSubmit={onSubmit}>
+          <Form
+            onSubmit={(event) => {
+              if (onSubmit) onSubmit(event);
+              else event.preventDefault();
+            }}
+          >
             {children}
             {actions}
           </Form>
-          <FooterNote>{footer}</FooterNote>
+          {footer ? <FooterNote>{footer}</FooterNote> : null}
         </FormPane>
 
         <Showcase>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -60,11 +60,20 @@ export function LoginPage() {
         { label: 'Dashboard', value: 'live' },
       ]}
       footer={
-        <AuthSwitchLink
-          prompt="New shop?"
-          to="/register"
-          label="Register ChartShop"
-        />
+        <div>
+          <AuthSwitchLink
+            prompt="New shop?"
+            to="/register"
+            label="Register ChartShop"
+          />
+          <div>
+            <AuthSwitchLink
+              prompt="Forgot PIN?"
+              to="/recover"
+              label="Use a recovery code"
+            />
+          </div>
+        </div>
       }
       onSubmit={onSubmit}
       actions={

--- a/frontend/src/pages/RecoverPage.tsx
+++ b/frontend/src/pages/RecoverPage.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import { Link, Navigate, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import { useAuth } from '@/auth';
+import { redeemRecovery } from '@/api/auth';
+import { ArrowButton } from '@/components/marketing/marketingPrimitives';
+import {
+  AuthShell,
+  AuthSwitchLink,
+  ErrorText,
+  Field,
+  Hint,
+  Input,
+} from '@/components/marketing/AuthShell';
+
+const ActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+`;
+
+const Success = styled.p`
+  margin: 0;
+  padding: 10px 12px;
+  background: ${({ theme }) => theme.colors.primaryTint};
+  color: ${({ theme }) => theme.colors.maroon};
+  font-size: 0.9rem;
+  line-height: 1.45;
+`;
+
+export function RecoverPage() {
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [code, setCode] = useState('');
+  const [newPin, setNewPin] = useState('');
+  const [confirmPin, setConfirmPin] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  if (isAuthenticated) {
+    return <Navigate to="/app" replace />;
+  }
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    const user = username.trim().toLowerCase();
+    if (!user || user.length < 3) {
+      setError('Enter your username.');
+      return;
+    }
+    if (!code.trim()) {
+      setError('Enter a recovery code.');
+      return;
+    }
+    if (!/^\d{4}$/.test(newPin)) {
+      setError('New PIN must be exactly 4 digits.');
+      return;
+    }
+    if (newPin !== confirmPin) {
+      setError('PINs do not match.');
+      return;
+    }
+
+    setPending(true);
+    try {
+      const result = await redeemRecovery({
+        username: user,
+        code: code.trim(),
+        newPin,
+      });
+      if (!result.success) {
+        setError(result.error || 'Recovery failed');
+        return;
+      }
+      setSuccess(
+        result.message ||
+          'PIN reset. Sign in with your new PIN. Generate new recovery codes in Settings after login.',
+      );
+      window.setTimeout(() => {
+        navigate('/login', { replace: true });
+      }, 2200);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Recovery failed');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <AuthShell
+      eyebrow="Account recovery"
+      headline="Reset your PIN with a recovery code"
+      lead="Enter your username, one unused recovery code, and a new 4-digit PIN."
+      showcaseTitle="Codes are one-time"
+      showcaseLead="Each code works once. After reset, sign in and regenerate a fresh set in Settings."
+      preview={[
+        { label: 'Need', value: '1 code' },
+        { label: 'Then', value: 'new PIN' },
+        { label: 'Sign in', value: '/login' },
+      ]}
+      footer={
+        <AuthSwitchLink prompt="Remembered your PIN?" to="/login" label="Sign in" />
+      }
+      onSubmit={onSubmit}
+      actions={
+        <ActionRow>
+          <ArrowButton type="submit" loading={pending}>
+            {pending ? 'Resetting…' : 'Reset PIN'}
+          </ArrowButton>
+        </ActionRow>
+      }
+    >
+      <Field>
+        Username
+        <Hint>The username you use to sign in</Hint>
+        <Input
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="e.g. musa"
+          autoComplete="username"
+          required
+        />
+      </Field>
+      <Field>
+        Recovery code
+        <Hint>Format like cs-xxxx-xxxx — spaces and dashes are fine</Hint>
+        <Input
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="cs-xxxx-xxxx"
+          autoComplete="off"
+          spellCheck={false}
+          required
+        />
+      </Field>
+      <Field>
+        New PIN
+        <Hint>Exactly 4 digits — avoid 1234 / 0000</Hint>
+        <Input
+          type="password"
+          inputMode="numeric"
+          pattern="\d{4}"
+          maxLength={4}
+          value={newPin}
+          onChange={(e) => setNewPin(e.target.value)}
+          placeholder="••••"
+          autoComplete="new-password"
+          required
+        />
+      </Field>
+      <Field>
+        Confirm new PIN
+        <Input
+          type="password"
+          inputMode="numeric"
+          pattern="\d{4}"
+          maxLength={4}
+          value={confirmPin}
+          onChange={(e) => setConfirmPin(e.target.value)}
+          placeholder="••••"
+          autoComplete="new-password"
+          required
+        />
+      </Field>
+      {error ? <ErrorText>{error}</ErrorText> : null}
+      {success ? (
+        <Success>
+          {success}{' '}
+          <Link to="/login">Go to sign in</Link>
+        </Success>
+      ) : null}
+    </AuthShell>
+  );
+}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useAuth } from '@/auth';
+import type { Shop } from '@/api/client';
+import { checkUsername } from '@/api/auth';
 import { ArrowButton } from '@/components/marketing/marketingPrimitives';
 import { TryDemoButton } from '@/components/demo/TryDemoButton';
 import {
@@ -13,6 +15,12 @@ import {
   Hint,
   Input,
 } from '@/components/marketing/AuthShell';
+import {
+  buildLocalSuggestions,
+  sanitizeUsernameInput,
+  validateUsername,
+} from '@/utils/username';
+import { RecoveryCodesPanel } from '@/components/auth/RecoveryCodesPanel';
 
 const ActionRow = styled.div`
   display: flex;
@@ -21,8 +29,83 @@ const ActionRow = styled.div`
   align-items: flex-start;
 `;
 
+const Preview = styled.p`
+  margin: 0;
+  font-size: 0.9rem;
+  color: ${({ theme }) => theme.colors.textSecondary};
+
+  strong {
+    color: ${({ theme }) => theme.colors.maroon};
+    font-weight: ${({ theme }) => theme.fontWeights.semibold};
+  }
+`;
+
+const Availability = styled.p<{ $tone: 'ok' | 'bad' | 'muted' }>`
+  margin: 0;
+  font-size: 0.82rem;
+  color: ${({ theme, $tone }) =>
+    $tone === 'ok'
+      ? theme.colors.success
+      : $tone === 'bad'
+        ? theme.colors.danger
+        : theme.colors.textMuted};
+`;
+
+const SuggestionBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const SuggestionLabel = styled.span`
+  font-size: 0.8rem;
+  font-weight: ${({ theme }) => theme.fontWeights.regular};
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const SuggestionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const SuggestionChip = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.cream};
+  color: ${({ theme }) => theme.colors.textPrimary};
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.borderStrong};
+    background: ${({ theme }) => theme.colors.surface};
+  }
+`;
+
+type AvailabilityState =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | {
+      status: 'ready';
+      available: boolean;
+      message?: string;
+      suggestions: string[];
+    };
+
+function mergeSuggestions(
+  primary: string[] | undefined,
+  desired: string,
+): string[] {
+  const fromApi = primary?.filter(Boolean) ?? [];
+  if (fromApi.length >= 3) return fromApi.slice(0, 3);
+  const local = buildLocalSuggestions(desired, 3, fromApi);
+  return [...fromApi, ...local].slice(0, 3);
+}
+
 export function RegisterPage() {
-  const { isAuthenticated, register } = useAuth();
+  const { isAuthenticated, register, establishSession } = useAuth();
   const navigate = useNavigate();
   const [businessName, setBusinessName] = useState('');
   const [username, setUsername] = useState('');
@@ -31,20 +114,110 @@ export function RegisterPage() {
   const [businessDescription, setBusinessDescription] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const [availability, setAvailability] = useState<AvailabilityState>({
+    status: 'idle',
+  });
+  const [issuedCodes, setIssuedCodes] = useState<string[] | null>(null);
+  const [pendingSession, setPendingSession] = useState<{
+    token: string;
+    shop: Shop;
+  } | null>(null);
 
-  if (isAuthenticated) {
+  useEffect(() => {
+    const normalized = username.trim().toLowerCase();
+    if (!normalized) {
+      setAvailability({ status: 'idle' });
+      return;
+    }
+
+    const validation = validateUsername(normalized);
+    const localSuggestions = buildLocalSuggestions(normalized);
+    let cancelled = false;
+
+    // Show local reason + suggestions immediately for reserved / invalid names.
+    if (!validation.valid) {
+      setAvailability({
+        status: 'ready',
+        available: false,
+        message: validation.message,
+        suggestions: localSuggestions,
+      });
+    } else {
+      setAvailability({ status: 'checking' });
+    }
+
+    const timer = window.setTimeout(async () => {
+      try {
+        const result = await checkUsername(normalized);
+        if (cancelled) return;
+
+        const available = Boolean(result.available);
+        setAvailability({
+          status: 'ready',
+          available,
+          message:
+            result.message ||
+            result.error ||
+            (validation.valid ? undefined : validation.message),
+          suggestions: available
+            ? []
+            : mergeSuggestions(result.suggestions, normalized),
+        });
+      } catch {
+        if (cancelled) return;
+        if (!validation.valid) {
+          setAvailability({
+            status: 'ready',
+            available: false,
+            message: validation.message,
+            suggestions: localSuggestions,
+          });
+        } else {
+          setAvailability({ status: 'idle' });
+        }
+      }
+    }, 350);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [username]);
+
+  if (isAuthenticated && !issuedCodes) {
     return <Navigate to="/app" replace />;
+  }
+
+  function finishRegistration() {
+    if (pendingSession) {
+      establishSession(pendingSession.token, pendingSession.shop);
+    }
+    setIssuedCodes(null);
+    setPendingSession(null);
+    navigate('/app', { replace: true });
   }
 
   async function onSubmit(event: FormEvent) {
     event.preventDefault();
     setError(null);
 
-    const normalized = username.trim().toLowerCase();
-    if (!/^[a-z0-9_]{3,32}$/.test(normalized)) {
-      setError(
-        'Username must be 3–32 characters: letters, numbers, underscore only.',
-      );
+    const validation = validateUsername(username);
+    if (!validation.valid) {
+      setError(validation.message);
+      setAvailability({
+        status: 'ready',
+        available: false,
+        message: validation.message,
+        suggestions: mergeSuggestions(undefined, username),
+      });
+      return;
+    }
+    if (
+      availability.status === 'ready' &&
+      !availability.available &&
+      availability.message
+    ) {
+      setError(availability.message);
       return;
     }
     if (!/^\d{4}$/.test(pin)) {
@@ -58,26 +231,106 @@ export function RegisterPage() {
 
     setPending(true);
     try {
-      await register({
-        username: normalized,
+      const result = await register({
+        username: validation.normalized,
         businessName: businessName.trim(),
         pin: pin.trim(),
         businessDescription:
           businessDescription.trim() || 'General merchandise',
       });
-      navigate('/app', { replace: true });
+      if (result.recoveryCodes.length > 0) {
+        setPendingSession({ token: result.token, shop: result.shop });
+        setIssuedCodes(result.recoveryCodes);
+      } else {
+        establishSession(result.token, result.shop);
+        navigate('/app', { replace: true });
+      }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Registration failed');
+      const message =
+        err instanceof Error ? err.message : 'Registration failed';
+      setError(message);
+      const fromErr =
+        err && typeof err === 'object' && 'suggestions' in err
+          ? (err as { suggestions?: string[] }).suggestions
+          : undefined;
+      let nextSuggestions = mergeSuggestions(fromErr, validation.normalized);
+      if (!fromErr?.length) {
+        try {
+          const check = await checkUsername(validation.normalized);
+          nextSuggestions = mergeSuggestions(
+            check.suggestions,
+            validation.normalized,
+          );
+        } catch {
+          /* keep local merge */
+        }
+      }
+      setAvailability({
+        status: 'ready',
+        available: false,
+        message,
+        suggestions: nextSuggestions,
+      });
     } finally {
       setPending(false);
     }
+  }
+
+  function applySuggestion(value: string) {
+    setUsername(value);
+    setError(null);
+  }
+
+  const previewName = username || null;
+
+  let availabilityTone: 'ok' | 'bad' | 'muted' = 'muted';
+  let availabilityText = '';
+  if (availability.status === 'checking') {
+    availabilityText = 'Checking availability…';
+  } else if (availability.status === 'ready') {
+    if (availability.available) {
+      availabilityTone = 'ok';
+      availabilityText = 'Username is available';
+    } else {
+      availabilityTone = 'bad';
+      availabilityText = availability.message || 'Username is not available';
+    }
+  }
+
+  const chipSuggestions =
+    availability.status === 'ready' && !availability.available
+      ? availability.suggestions
+      : [];
+
+  if (issuedCodes) {
+    return (
+      <AuthShell
+        eyebrow="Save these codes"
+        headline="Your only free way to reset a lost PIN"
+        lead="Copy or download them now. ChartShop never shows plaintext recovery codes again."
+        showcaseTitle="Keep them offline"
+        showcaseLead="Losing both your PIN and these codes can lock the shop permanently."
+        preview={[
+          { label: 'Codes', value: String(issuedCodes.length) },
+          { label: 'Use once', value: 'each' },
+          { label: 'Reset', value: '/recover' },
+        ]}
+        actions={null}
+      >
+        <RecoveryCodesPanel
+          codes={issuedCodes}
+          username={pendingSession?.shop.username || username}
+          onContinue={finishRegistration}
+        />
+      </AuthShell>
+    );
   }
 
   return (
     <AuthShell
       eyebrow="Open your shop"
       headline="Register the till in minutes"
-      lead="Pick a shop name, a username, and a 4-digit PIN — same credentials work in chat."
+      lead="Pick a shop name, a username, and a 4-digit PIN — same credentials work in chat. You will get recovery codes once after signup."
       showcaseTitle="First sale starts with a message"
       showcaseLead="After register, you can sell from Telegram, WhatsApp, or this dashboard."
       preview={[
@@ -86,7 +339,20 @@ export function RegisterPage() {
         { label: 'Books', value: 'synced' },
       ]}
       footer={
-        <AuthSwitchLink prompt="Already registered?" to="/login" label="Sign in" />
+        <div>
+          <AuthSwitchLink
+            prompt="Already registered?"
+            to="/login"
+            label="Sign in"
+          />
+          <div>
+            <AuthSwitchLink
+              prompt="Lost your PIN?"
+              to="/recover"
+              label="Use a recovery code"
+            />
+          </div>
+        </div>
       }
       onSubmit={onSubmit}
       actions={
@@ -111,15 +377,46 @@ export function RegisterPage() {
       </Field>
       <Field>
         Username
-        <Hint>3–32 chars · letters, numbers, underscore · used on all platforms</Hint>
+        <Hint>
+          3–15 lowercase letters · optional digits at the end · used on all
+          platforms
+        </Hint>
         <Input
           value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          placeholder="e.g. tinasales"
+          onChange={(e) => {
+            setUsername(sanitizeUsernameInput(e.target.value));
+            setError(null);
+          }}
+          placeholder="e.g. musa"
           autoComplete="username"
-          pattern="[A-Za-z0-9_]{3,32}"
+          maxLength={15}
+          spellCheck={false}
           required
         />
+        {previewName ? (
+          <Preview>
+            Your username will be <strong>@{previewName}</strong>
+          </Preview>
+        ) : null}
+        {availabilityText ? (
+          <Availability $tone={availabilityTone}>{availabilityText}</Availability>
+        ) : null}
+        {chipSuggestions.length > 0 ? (
+          <SuggestionBlock>
+            <SuggestionLabel>Try one of these instead</SuggestionLabel>
+            <SuggestionRow>
+              {chipSuggestions.map((s) => (
+                <SuggestionChip
+                  key={s}
+                  type="button"
+                  onClick={() => applySuggestion(s)}
+                >
+                  @{s}
+                </SuggestionChip>
+              ))}
+            </SuggestionRow>
+          </SuggestionBlock>
+        ) : null}
       </Field>
       <Field>
         What you sell
@@ -159,6 +456,10 @@ export function RegisterPage() {
           required
         />
       </Field>
+      <Hint as="p" style={{ margin: 0 }}>
+        After signup you will get recovery codes once. Save them — they are the
+        free way to reset a lost PIN.
+      </Hint>
       {error ? <ErrorText>{error}</ErrorText> : null}
     </AuthShell>
   );

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import type { FormEvent } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 import styled from 'styled-components';
+import axios from 'axios';
 import {
   Building2,
   KeyRound,
@@ -14,10 +15,17 @@ import {
   updateProfileName,
   updateProfileDescription,
   updateProfilePin,
+  updateProfileUsername,
 } from '@/api/reports';
+import {
+  checkUsername,
+  fetchRecoveryStatus,
+  regenerateRecoveryCodes,
+} from '@/api/auth';
 import { getErrorMessage } from '@/api/types';
 import { useAuth } from '@/auth';
 import { BrandMark } from '@/components/ui/BrandMark';
+import { RecoveryCodesPanel } from '@/components/auth/RecoveryCodesPanel';
 import {
   Page,
   PageTitle,
@@ -33,7 +41,11 @@ import {
   Badge,
 } from '@/components/ui/primitives';
 import { SettingsProfileSkeleton } from '@/components/skeletons/PageSkeletons';
-
+import {
+  buildLocalSuggestions,
+  sanitizeUsernameInput,
+  validateUsername,
+} from '@/utils/username';
 const Header = styled.header`
   margin-bottom: ${({ theme }) => theme.space[5]};
 `;
@@ -185,6 +197,72 @@ const FormActions = styled.div`
   margin-top: ${({ theme }) => theme.space[5]};
 `;
 
+const FieldHint = styled.span`
+  font-weight: ${({ theme }) => theme.fontWeights.regular};
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-size: 0.8rem;
+`;
+
+const RecoveryStatusText = styled.p`
+  margin: 0 0 12px;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: 0.9rem;
+  line-height: 1.45;
+`;
+
+const Preview = styled.p`
+  margin: 0;
+  font-size: 0.85rem;
+  color: ${({ theme }) => theme.colors.textSecondary};
+
+  strong {
+    color: ${({ theme }) => theme.colors.maroon};
+  }
+`;
+
+const Availability = styled.p<{ $tone: 'ok' | 'bad' | 'muted' }>`
+  margin: 0;
+  font-size: 0.82rem;
+  color: ${({ theme, $tone }) =>
+    $tone === 'ok'
+      ? theme.colors.success
+      : $tone === 'bad'
+        ? theme.colors.danger
+        : theme.colors.textMuted};
+`;
+
+const SuggestionBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const SuggestionLabel = styled.span`
+  font-size: 0.8rem;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const SuggestionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const SuggestionChip = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.cream};
+  color: ${({ theme }) => theme.colors.textPrimary};
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.borderStrong};
+    background: ${({ theme }) => theme.colors.surface};
+  }
+`;
+
 const SessionCard = styled(Card)`
   background: linear-gradient(
     145deg,
@@ -202,6 +280,32 @@ type ProfilePayload = {
   isLoggedIn?: boolean;
 };
 
+type UsernameAvailability =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | {
+      status: 'ready';
+      available: boolean;
+      message?: string;
+      suggestions: string[];
+    };
+
+function mergeSuggestions(
+  primary: string[] | undefined,
+  desired: string,
+): string[] {
+  const fromApi = primary?.filter(Boolean) ?? [];
+  if (fromApi.length >= 3) return fromApi.slice(0, 3);
+  const local = buildLocalSuggestions(desired, 3, fromApi);
+  return [...fromApi, ...local].slice(0, 3);
+}
+
+function suggestionsFromError(error: unknown): string[] {
+  if (!axios.isAxiosError(error)) return [];
+  const data = error.response?.data as { suggestions?: string[] } | undefined;
+  return data?.suggestions || [];
+}
+
 function formatDate(value?: string | null) {
   if (!value) return 'Never';
   try {
@@ -215,6 +319,7 @@ export function SettingsPage() {
   const { shop, logout, updateShop } = useAuth();
   const qc = useQueryClient();
   const [name, setName] = useState(shop?.businessName || '');
+  const [username, setUsername] = useState(shop?.username || '');
   const [description, setDescription] = useState(
     shop?.businessDescription || '',
   );
@@ -222,6 +327,8 @@ export function SettingsPage() {
   const [error, setError] = useState<string | null>(null);
   const [ok, setOk] = useState<string | null>(null);
   const [loggingOut, setLoggingOut] = useState(false);
+  const [usernameAvailability, setUsernameAvailability] =
+    useState<UsernameAvailability>({ status: 'idle' });
 
   const profileQ = useQuery({
     queryKey: ['profile'],
@@ -241,6 +348,7 @@ export function SettingsPage() {
     const loaded = profileQ.data?.shop;
     if (!loaded) return;
     setName(loaded.businessName || '');
+    setUsername(loaded.username || '');
     setDescription(loaded.businessDescription || '');
   }, [profileQ.data?.shop]);
 
@@ -253,6 +361,74 @@ export function SettingsPage() {
     return () => window.clearTimeout(t);
   }, [ok, error]);
 
+  useEffect(() => {
+    const normalized = username.trim().toLowerCase();
+    const current = (shop?.username || '').toLowerCase();
+    if (!normalized) {
+      setUsernameAvailability({ status: 'idle' });
+      return;
+    }
+    if (normalized === current) {
+      setUsernameAvailability({
+        status: 'ready',
+        available: true,
+        suggestions: [],
+      });
+      return;
+    }
+
+    const validation = validateUsername(normalized);
+    const localSuggestions = buildLocalSuggestions(normalized);
+    let cancelled = false;
+
+    if (!validation.valid) {
+      setUsernameAvailability({
+        status: 'ready',
+        available: false,
+        message: validation.message,
+        suggestions: localSuggestions,
+      });
+    } else {
+      setUsernameAvailability({ status: 'checking' });
+    }
+
+    const timer = window.setTimeout(async () => {
+      try {
+        const result = await checkUsername(normalized);
+        if (cancelled) return;
+        const available = Boolean(result.available);
+        setUsernameAvailability({
+          status: 'ready',
+          available,
+          message:
+            result.message ||
+            result.error ||
+            (validation.valid ? undefined : validation.message),
+          suggestions: available
+            ? []
+            : mergeSuggestions(result.suggestions, normalized),
+        });
+      } catch {
+        if (cancelled) return;
+        if (!validation.valid) {
+          setUsernameAvailability({
+            status: 'ready',
+            available: false,
+            message: validation.message,
+            suggestions: localSuggestions,
+          });
+        } else {
+          setUsernameAvailability({ status: 'idle' });
+        }
+      }
+    }, 350);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [username, shop?.username]);
+
   const saveName = useMutation({
     mutationFn: () => updateProfileName(name.trim()),
     onSuccess: () => {
@@ -262,6 +438,33 @@ export function SettingsPage() {
       void qc.invalidateQueries({ queryKey: ['profile'] });
     },
     onError: (e) => setError(getErrorMessage(e)),
+  });
+
+  const saveUsername = useMutation({
+    mutationFn: () => updateProfileUsername(username.trim().toLowerCase()),
+    onSuccess: (data) => {
+      const next = data.shop?.username || username.trim().toLowerCase();
+      setOk(data.message || 'Username updated.');
+      setError(null);
+      setUsername(next);
+      updateShop({ username: next });
+      setUsernameAvailability({
+        status: 'ready',
+        available: true,
+        suggestions: [],
+      });
+      void qc.invalidateQueries({ queryKey: ['profile'] });
+    },
+    onError: (e) => {
+      setError(getErrorMessage(e));
+      const desired = username.trim().toLowerCase();
+      setUsernameAvailability({
+        status: 'ready',
+        available: false,
+        message: getErrorMessage(e),
+        suggestions: mergeSuggestions(suggestionsFromError(e), desired),
+      });
+    },
   });
 
   const saveDesc = useMutation({
@@ -285,6 +488,29 @@ export function SettingsPage() {
     onError: (e) => setError(getErrorMessage(e)),
   });
 
+  const recoveryQ = useQuery({
+    queryKey: ['recovery-status'],
+    queryFn: fetchRecoveryStatus,
+    enabled: Boolean(shop) && !shop?.isDemo,
+  });
+
+  const [freshCodes, setFreshCodes] = useState<string[] | null>(null);
+
+  const regenCodes = useMutation({
+    mutationFn: regenerateRecoveryCodes,
+    onSuccess: (data) => {
+      if (!data.success || !data.recoveryCodes?.length) {
+        setError(data.error || 'Could not regenerate codes');
+        return;
+      }
+      setFreshCodes(data.recoveryCodes);
+      setOk('New recovery codes issued — save them now.');
+      setError(null);
+      void qc.invalidateQueries({ queryKey: ['recovery-status'] });
+    },
+    onError: (e) => setError(getErrorMessage(e)),
+  });
+
   function onName(e: FormEvent) {
     e.preventDefault();
     setError(null);
@@ -293,6 +519,34 @@ export function SettingsPage() {
       return;
     }
     saveName.mutate();
+  }
+
+  function onUsername(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const validation = validateUsername(username);
+    if (!validation.valid) {
+      setError(validation.message);
+      setUsernameAvailability({
+        status: 'ready',
+        available: false,
+        message: validation.message,
+        suggestions: mergeSuggestions(undefined, username),
+      });
+      return;
+    }
+    if (
+      usernameAvailability.status === 'ready' &&
+      !usernameAvailability.available
+    ) {
+      setError(usernameAvailability.message || 'Username is not available.');
+      return;
+    }
+    if (validation.normalized === (shop?.username || '').toLowerCase()) {
+      setOk('Username unchanged.');
+      return;
+    }
+    saveUsername.mutate();
   }
 
   function onDesc(e: FormEvent) {
@@ -330,6 +584,30 @@ export function SettingsPage() {
   }
 
   const shopName = profile?.businessName || shop?.businessName || 'Your shop';
+  const displayUsername = shop?.username || 'no username';
+
+  let usernameTone: 'ok' | 'bad' | 'muted' = 'muted';
+  let usernameStatusText = '';
+  if (usernameAvailability.status === 'checking') {
+    usernameStatusText = 'Checking availability…';
+  } else if (usernameAvailability.status === 'ready') {
+    if (usernameAvailability.available) {
+      usernameTone = 'ok';
+      usernameStatusText =
+        username.trim().toLowerCase() === (shop?.username || '').toLowerCase()
+          ? 'This is your current username'
+          : 'Username is available';
+    } else {
+      usernameTone = 'bad';
+      usernameStatusText =
+        usernameAvailability.message || 'Username is not available';
+    }
+  }
+
+  const usernameChips =
+    usernameAvailability.status === 'ready' && !usernameAvailability.available
+      ? usernameAvailability.suggestions
+      : [];
 
   return (
     <Page>
@@ -349,7 +627,7 @@ export function SettingsPage() {
             <BrandMark size={48} />
             <ShopMeta>
               <strong>{shopName}</strong>
-              <span>@{shop?.username || 'no username'}</span>
+              <span>@{displayUsername}</span>
             </ShopMeta>
           </ShopBlock>
           {profile?.isLoggedIn || shop ? (
@@ -386,8 +664,8 @@ export function SettingsPage() {
             </IconBadge>
             <SectionCopy>
               <h2>Shop profile</h2>
-              <p>Name and description shown on reports and in the app header.</p>
-              <Command>profile edit name · profile edit description</Command>
+              <p>Username, name, and description used across web and chat.</p>
+              <Command>profile edit username · profile edit name · profile edit description</Command>
             </SectionCopy>
           </SectionHead>
 
@@ -395,7 +673,63 @@ export function SettingsPage() {
             <SettingsProfileSkeleton />
           ) : (
             <>
-          <form onSubmit={onName}>
+          <form onSubmit={onUsername}>
+            <Field>
+              Username
+              <FieldHint>
+                3–15 lowercase letters · optional digits at the end · same login
+                on all platforms
+              </FieldHint>
+              <Input
+                value={username}
+                onChange={(e) => {
+                  setUsername(sanitizeUsernameInput(e.target.value));
+                  setError(null);
+                }}
+                placeholder="e.g. musa"
+                autoComplete="username"
+                maxLength={15}
+                spellCheck={false}
+                required
+              />
+              {username ? (
+                <Preview>
+                  Login will be <strong>@{username}</strong>
+                </Preview>
+              ) : null}
+              {usernameStatusText ? (
+                <Availability $tone={usernameTone}>
+                  {usernameStatusText}
+                </Availability>
+              ) : null}
+              {usernameChips.length > 0 ? (
+                <SuggestionBlock>
+                  <SuggestionLabel>Try one of these instead</SuggestionLabel>
+                  <SuggestionRow>
+                    {usernameChips.map((s) => (
+                      <SuggestionChip
+                        key={s}
+                        type="button"
+                        onClick={() => {
+                          setUsername(s);
+                          setError(null);
+                        }}
+                      >
+                        @{s}
+                      </SuggestionChip>
+                    ))}
+                  </SuggestionRow>
+                </SuggestionBlock>
+              ) : null}
+            </Field>
+            <FormActions>
+              <Button type="submit" loading={saveUsername.isPending}>
+                {saveUsername.isPending ? 'Saving…' : 'Save username'}
+              </Button>
+            </FormActions>
+          </form>
+
+          <form onSubmit={onName} style={{ marginTop: 28 }}>
             <Field>
               Business name
               <Input
@@ -502,6 +836,66 @@ export function SettingsPage() {
             </FormActions>
           </form>
         </Card>
+
+        {!shop?.isDemo ? (
+          <Card>
+            <SectionHead>
+              <IconBadge>
+                <KeyRound size={18} />
+              </IconBadge>
+              <SectionCopy>
+                <h2>Recovery codes</h2>
+                <p>
+                  One-time codes to reset a lost PIN. Shown only when generated —
+                  ChartShop stores hashes only.
+                </p>
+              </SectionCopy>
+            </SectionHead>
+
+            {freshCodes ? (
+              <RecoveryCodesPanel
+                codes={freshCodes}
+                username={shop?.username}
+                continueLabel="Done — hide codes"
+                onContinue={() => setFreshCodes(null)}
+              />
+            ) : (
+              <>
+                <RecoveryStatusText>
+                  {recoveryQ.isLoading
+                    ? 'Checking…'
+                    : recoveryQ.data?.hasCodes
+                      ? `${recoveryQ.data.remaining} unused code${
+                          recoveryQ.data.remaining === 1 ? '' : 's'
+                        } remaining. Regenerating revokes unused old codes.`
+                      : 'No unused recovery codes. Generate a set and save them offline — this is how you reset a lost PIN.'}
+                </RecoveryStatusText>
+                <FormActions>
+                  <Button
+                    type="button"
+                    loading={regenCodes.isPending}
+                    onClick={() => {
+                      if (
+                        !window.confirm(
+                          'This revokes unused old codes and shows a new set once. Continue?',
+                        )
+                      ) {
+                        return;
+                      }
+                      regenCodes.mutate();
+                    }}
+                  >
+                    {regenCodes.isPending
+                      ? 'Generating…'
+                      : recoveryQ.data?.hasCodes
+                        ? 'Regenerate codes'
+                        : 'Generate recovery codes'}
+                  </Button>
+                </FormActions>
+              </>
+            )}
+          </Card>
+        ) : null}
 
         <SessionCard>
           <SectionHead>

--- a/frontend/src/utils/username.ts
+++ b/frontend/src/utils/username.ts
@@ -1,0 +1,120 @@
+/**
+ * Client-side mirror of backend/utils/usernamePolicy.js for register UX.
+ * Server remains the source of truth for availability; local helpers power
+ * instant feedback and offline suggestion chips.
+ */
+
+export const USERNAME_MIN = 3;
+export const USERNAME_MAX = 15;
+export const USERNAME_PATTERN = /^(?=.{3,15}$)[a-z]+[0-9]*$/;
+
+export const RESERVED_USERNAMES = new Set([
+  'admin',
+  'support',
+  'system',
+  'chartshop',
+]);
+
+export function normalizeUsername(username: string): string {
+  return String(username || '')
+    .trim()
+    .toLowerCase();
+}
+
+/** Soft-normalize while typing: lowercase, strip disallowed characters. */
+export function sanitizeUsernameInput(raw: string): string {
+  return String(raw || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+    .slice(0, USERNAME_MAX);
+}
+
+export type UsernameValidation =
+  | { valid: true; normalized: string }
+  | { valid: false; normalized: string; message: string };
+
+export function validateUsername(username: string): UsernameValidation {
+  const normalized = normalizeUsername(username);
+
+  if (!normalized) {
+    return {
+      valid: false,
+      normalized,
+      message: 'Username cannot be empty',
+    };
+  }
+  if (normalized.length < USERNAME_MIN) {
+    return {
+      valid: false,
+      normalized,
+      message: `Username must be at least ${USERNAME_MIN} characters`,
+    };
+  }
+  if (normalized.length > USERNAME_MAX) {
+    return {
+      valid: false,
+      normalized,
+      message: `Username must be at most ${USERNAME_MAX} characters`,
+    };
+  }
+  if (!USERNAME_PATTERN.test(normalized)) {
+    return {
+      valid: false,
+      normalized,
+      message:
+        'Use lowercase letters only, with optional digits at the end (no spaces or symbols)',
+    };
+  }
+  if (RESERVED_USERNAMES.has(normalized)) {
+    return {
+      valid: false,
+      normalized,
+      message: `"${normalized}" is reserved. Please choose a different username`,
+    };
+  }
+
+  return { valid: true, normalized };
+}
+
+/** Letter prefix used when suggesting alternatives (strip trailing digits). */
+export function usernameLetterRoot(username: string): string {
+  const normalized = normalizeUsername(username);
+  const root = normalized.replace(/[0-9]+$/, '').replace(/[^a-z]/g, '');
+  if (root.length >= 2) return root.slice(0, USERNAME_MAX - 1);
+  if (root.length === 1) return `${root}u`.slice(0, USERNAME_MAX - 1);
+  return 'shop';
+}
+
+/**
+ * Local alternatives like musa1, musa2 (does not check the server).
+ * Prefer API suggestions when online so taken names are filtered out.
+ */
+export function buildLocalSuggestions(
+  desired: string,
+  count = 3,
+  exclude: Iterable<string> = [],
+): string[] {
+  const excluded = new Set(
+    [...exclude, normalizeUsername(desired)].map((s) => normalizeUsername(s)),
+  );
+  const root = usernameLetterRoot(desired);
+  const suggestions: string[] = [];
+  let n = 1;
+
+  while (suggestions.length < count && n < 1000) {
+    const suffix = String(n);
+    const maxLetters = USERNAME_MAX - suffix.length;
+    if (maxLetters < 2) break;
+
+    const candidate = `${root.slice(0, maxLetters)}${suffix}`;
+    n += 1;
+
+    if (!USERNAME_PATTERN.test(candidate)) continue;
+    if (RESERVED_USERNAMES.has(candidate)) continue;
+    if (excluded.has(candidate)) continue;
+
+    suggestions.push(candidate);
+  }
+
+  return suggestions;
+}


### PR DESCRIPTION
Tighten signup usernames (letters + trailing digits, reserved names, live availability) and allow username changes, with one-time recovery codes as the free path to reset a lost PIN across web and chat.