### PR TITLE
Add product variants and packs

### DIFF
--- a/frontend/src/components/products/ProductLineFields.tsx
+++ b/frontend/src/components/products/ProductLineFields.tsx
@@ -66,9 +66,10 @@ export function ProductLineFields({
       </Field>
 
       {needVariant ? (
-        <Field>
-          Variant (size, packs)
+        <Field style={{ flex: '1.4 1 180px' }}>
+          Option
           <Select
+            key={`variant-${line.productId}`}
             value={line.variantId}
             onChange={(e) => {
               const packsFor = activePacks(product, e.target.value);
@@ -82,13 +83,17 @@ export function ProductLineFields({
             }}
             required
           >
-            {variants.map((v) => (
-              <option key={v.id} value={v.id}>
-                {v.label?.trim() || 'Default'}
-                {v.trackStock ? ` · stock ${v.stock}` : ''}
-                {` · ${money(v.price)}`}
-              </option>
-            ))}
+            {variants.length === 0 ? (
+              <option value="">No options</option>
+            ) : (
+              variants.map((v) => (
+                <option key={v.id} value={v.id}>
+                  {v.label?.trim() || 'Standard'}
+                  {v.trackStock ? ` · stock ${v.stock}` : ''}
+                  {` · ${money(v.price)}`}
+                </option>
+              ))
+            )}
           </Select>
         </Field>
       ) : null}
@@ -97,6 +102,7 @@ export function ProductLineFields({
         <Field>
           Pack
           <Select
+            key={`pack-${line.productId}-${line.variantId}`}
             value={line.packId}
             onChange={(e) =>
               onChange({

--- a/frontend/src/components/ui/primitives.tsx
+++ b/frontend/src/components/ui/primitives.tsx
@@ -42,7 +42,8 @@ export const Card = styled.section`
   box-shadow: ${({ theme }) => theme.shadows.card};
   padding: ${({ theme }) => theme.space[4]};
   margin-bottom: ${({ theme }) => theme.space[4]};
-  overflow: hidden;
+  /* visible so <select> menus / expanded panels are not clipped */
+  overflow: visible;
   min-width: 0;
   max-width: 100%;
 
@@ -88,14 +89,16 @@ const controlBase = `
     background 0.15s ease;
 `;
 
-export const Input = styled.input`
+export const Input = styled.input<{ $invalid?: boolean }>`
   ${controlBase}
   width: 100%;
   max-width: 100%;
-  border-color: ${({ theme }) => theme.colors.border};
+  border-color: ${({ theme, $invalid }) =>
+    $invalid ? theme.colors.danger : theme.colors.border};
   border-radius: 0;
   padding: 11px 13px;
-  background: ${({ theme }) => theme.colors.cream};
+  background: ${({ theme, $invalid }) =>
+    $invalid ? theme.colors.dangerTint : theme.colors.cream};
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.textMuted};
@@ -103,8 +106,11 @@ export const Input = styled.input`
 
   &:focus {
     outline: none;
-    border-color: ${({ theme }) => theme.colors.borderStrong};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.primaryTint};
+    border-color: ${({ theme, $invalid }) =>
+      $invalid ? theme.colors.danger : theme.colors.borderStrong};
+    box-shadow: 0 0 0 3px
+      ${({ theme, $invalid }) =>
+        $invalid ? theme.colors.dangerTint : theme.colors.primaryTint};
     background: ${({ theme }) => theme.colors.surface};
   }
 `;
@@ -149,7 +155,8 @@ export const TableWrap = styled.div<{ $compact?: boolean }>`
   width: 100%;
   max-width: 100%;
   overflow-x: ${({ $compact }) => ($compact ? 'hidden' : 'auto')};
-  overflow-y: hidden;
+  /* auto (not hidden) so expanded variant panels inside tables stay reachable */
+  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-x: contain;
   scrollbar-width: thin;
@@ -352,8 +359,7 @@ export const Tabs = styled.div`
 export const Tab = styled.button<{ $active?: boolean }>`
   border: none;
   flex: 0 0 auto;
-  background: ${({ theme, $active }) =>
-    $active ? theme.colors.surface : 'transparent'};
+  background: ${({ theme, $active }) => ($active ? theme.colors.surface : 'transparent')};
   color: ${({ theme }) => theme.colors.maroon};
   border-radius: 0;
   padding: 9px 14px;
@@ -362,7 +368,9 @@ export const Tab = styled.button<{ $active?: boolean }>`
   font-family: inherit;
   cursor: pointer;
   box-shadow: ${({ theme, $active }) => ($active ? theme.shadows.card : 'none')};
-  transition: background 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease;
 
   &:hover {
     background: ${({ theme, $active }) =>

--- a/frontend/src/pages/LaybyesPage.tsx
+++ b/frontend/src/pages/LaybyesPage.tsx
@@ -105,7 +105,7 @@ export function LaybyesPage() {
       <PageTitle>Laybyes</PageTitle>
       <PageLead>
         Create agreements, take deposits and installments, and complete when paid in full.
-        Pick size/pack when a product has options.
+        Pick option/pack when a product has them.
       </PageLead>
 
       <Card>

--- a/frontend/src/pages/OrdersPage.tsx
+++ b/frontend/src/pages/OrdersPage.tsx
@@ -147,7 +147,7 @@ export function OrdersPage() {
     <Page>
       <PageTitle>Orders</PageTitle>
       <PageLead>
-        Pickup / delivery orders — pending until completed or cancelled. Choose size/pack
+        Pickup / delivery orders — pending until completed or cancelled. Choose option/pack
         when the product has options.
       </PageLead>
 

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, Fragment } from 'react';
+import { useMemo, useState } from 'react';
 import type { FormEvent } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
@@ -24,6 +24,7 @@ import {
   Row,
   Field,
   Input,
+  Select,
   Button,
   Table,
   Badge,
@@ -35,7 +36,145 @@ import { useGuardDemoWrite } from '@/components/demo/DemoUpgradeProvider';
 import { TableSkeleton } from '@/components/ui/Skeleton';
 import { ProductsSummarySkeleton } from '@/components/skeletons/PageSkeletons';
 import { toastError, toastSuccess } from '@/lib/toast';
-import { productHasOptions } from '@/utils/productCatalog';
+import { activeVariants, productHasOptions } from '@/utils/productCatalog';
+
+const VariantsPanel = styled.div`
+  margin-top: ${({ theme }) => theme.space[4]};
+  padding-top: ${({ theme }) => theme.space[4]};
+  border-top: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.space[3]};
+  margin-bottom: ${({ theme }) => theme.space[4]};
+`;
+
+const PanelTitle = styled.h3`
+  margin: 0;
+  font-family: ${({ theme }) => theme.fonts.heading};
+  font-size: 1.1rem;
+  font-weight: ${({ theme }) => theme.fontWeights.semibold};
+  color: ${({ theme }) => theme.colors.maroon};
+`;
+
+const PanelLead = styled.p`
+  margin: 4px 0 0;
+  max-width: 36rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const SizeList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.space[3]};
+  margin-bottom: ${({ theme }) => theme.space[4]};
+`;
+
+const SizeRow = styled.div`
+  display: grid;
+  gap: ${({ theme }) => theme.space[3]};
+  padding: ${({ theme }) => theme.space[3]};
+  background: ${({ theme }) => theme.colors.cream};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+
+  @media (min-width: 720px) {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+`;
+
+const SizeMeta = styled.div`
+  min-width: 0;
+`;
+
+const SizeName = styled.div`
+  font-weight: ${({ theme }) => theme.fontWeights.semibold};
+  color: ${({ theme }) => theme.colors.textPrimary};
+  font-size: 1rem;
+`;
+
+const SizeDetails = styled.div`
+  margin-top: 4px;
+  font-size: 0.88rem;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  line-height: 1.4;
+`;
+
+const SizeStock = styled.span`
+  display: inline-block;
+  margin-top: 6px;
+  font-weight: ${({ theme }) => theme.fontWeights.semibold};
+  color: ${({ theme }) => theme.colors.maroon};
+`;
+
+const SizeActions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: ${({ theme }) => theme.space[2]};
+`;
+
+const StockLabel = styled.span`
+  font-size: 0.78rem;
+  font-weight: ${({ theme }) => theme.fontWeights.semibold};
+  color: ${({ theme }) => theme.colors.textMuted};
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  width: 100%;
+
+  @media (min-width: 720px) {
+    width: auto;
+    margin-right: 4px;
+  }
+`;
+
+const SecondaryActions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${({ theme }) => theme.space[2]};
+  margin-bottom: ${({ theme }) => theme.space[3]};
+`;
+
+const AddSection = styled.div`
+  margin-top: ${({ theme }) => theme.space[3]};
+  padding: ${({ theme }) => theme.space[3]};
+  border: 1px dashed ${({ theme }) => theme.colors.borderStrong};
+  background: ${({ theme }) => theme.colors.surface};
+`;
+
+const AddSectionTitle = styled.div`
+  font-weight: ${({ theme }) => theme.fontWeights.semibold};
+  margin-bottom: 4px;
+  color: ${({ theme }) => theme.colors.maroon};
+`;
+
+const AddSectionLead = styled.p`
+  margin: 0 0 ${({ theme }) => theme.space[3]};
+  font-size: 0.88rem;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  line-height: 1.4;
+`;
+
+const FieldHint = styled.span<{ $error?: boolean }>`
+  font-size: 0.75rem;
+  font-weight: ${({ theme }) => theme.fontWeights.regular};
+  color: ${({ theme, $error }) =>
+    $error ? theme.colors.danger : theme.colors.textMuted};
+`;
+
+type CreateRowErrors = {
+  label?: string;
+  price?: string;
+  stock?: string;
+};
+
+type PanelMode = 'list' | 'add-option' | 'add-pack';
 
 type FilterTab = 'all' | 'low' | 'out';
 
@@ -220,15 +359,18 @@ export function ProductsPage() {
   });
   const [createOptions, setCreateOptions] = useState<
     Array<{ label: string; price: string; costPrice: string; stock: string }>
-  >([{ label: '', price: '', costPrice: '', stock: '0' }]);
+  >([{ label: '', price: '', costPrice: '', stock: '' }]);
+  const [createErrors, setCreateErrors] = useState<CreateRowErrors[]>([]);
   const [stockEdit, setStockEdit] = useState<Record<string, string>>({});
   const [rowBusy, setRowBusy] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Product | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [panelMode, setPanelMode] = useState<PanelMode>('list');
+  const [editName, setEditName] = useState('');
   const [variantForm, setVariantForm] = useState({
     label: '',
     price: '',
-    stock: '0',
+    stock: '',
   });
   const [packForm, setPackForm] = useState({
     variantId: '',
@@ -237,12 +379,54 @@ export function ProductsPage() {
     price: '',
   });
 
+  function openEditPanel(p: Product) {
+    const variants = activeVariants(p);
+    setExpandedId(p.id);
+    setPanelMode('list');
+    setEditName(p.name);
+    setVariantForm({ label: '', price: '', stock: '' });
+    setPackForm({
+      variantId: variants[0]?.id || '',
+      label: '',
+      unitsPerPack: '24',
+      price: '',
+    });
+  }
+
+  function closeEditPanel() {
+    setExpandedId(null);
+    setPanelMode('list');
+    setEditName('');
+  }
+
+  async function saveProductName(p: Product) {
+    const trimmed = editName.trim();
+    if (!trimmed || trimmed === p.name) return;
+    if (guardDemoWrite('change products')) {
+      setEditName(p.name);
+      return;
+    }
+    try {
+      await updateProduct(p.id, { name: trimmed });
+      toastSuccess('Product name updated.');
+      invalidate();
+    } catch (err) {
+      toastError(getErrorMessage(err));
+      setEditName(p.name);
+    }
+  }
+
   const productsQ = useQuery({
     queryKey: ['products', 'all'],
     queryFn: listProducts,
   });
 
   const products = useMemo(() => productsQ.data || [], [productsQ.data]);
+
+  const expandedProduct = useMemo(
+    () => (expandedId ? products.find((p) => p.id === expandedId) || null : null),
+    [expandedId, products],
+  );
 
   const invalidate = () => {
     void qc.invalidateQueries({ queryKey: ['products'] });
@@ -257,7 +441,8 @@ export function ProductsPage() {
         name: '',
         lowStockThreshold: defaultThreshold,
       });
-      setCreateOptions([{ label: '', price: '', costPrice: '', stock: '0' }]);
+      setCreateOptions([{ label: '', price: '', costPrice: '', stock: '' }]);
+      setCreateErrors([]);
       invalidate();
     },
     onError: (e) => toastError(getErrorMessage(e)),
@@ -294,38 +479,80 @@ export function ProductsPage() {
     }
 
     const threshold = Number(form.lowStockThreshold) || Number(defaultThreshold) || 10;
+    const multi = createOptions.length > 1;
 
-    const variants = createOptions
-      .map((row) => {
-        const price = Number(row.price);
-        const costRaw = row.costPrice.trim();
-        const costPrice = costRaw === '' ? null : Number(costRaw);
-        return {
-          label: row.label.trim(),
-          price,
-          costPrice:
-            costPrice != null && Number.isFinite(costPrice) && costPrice >= 0
-              ? costPrice
-              : null,
-          stock: Number(row.stock) || 0,
-          lowStockThreshold: threshold,
-        };
-      })
-      .filter((row) => Number.isFinite(row.price) && row.price > 0);
+    const rowErrors: CreateRowErrors[] = createOptions.map((row) => {
+      const errs: CreateRowErrors = {};
+      const price = Number(row.price);
+      const stock = Number(row.stock);
+      if (multi && !row.label.trim()) {
+        errs.label = 'Label required';
+      }
+      if (!Number.isFinite(price) || price <= 0) {
+        errs.price = 'Price required';
+      }
+      if (!Number.isFinite(stock) || stock <= 0) {
+        errs.stock = 'Stock must be > 0';
+      }
+      return errs;
+    });
 
-    if (variants.length === 0) {
-      toastError('Add a price on at least one row.');
+    const hasErrors = rowErrors.some((e) => e.label || e.price || e.stock);
+    setCreateErrors(rowErrors);
+    if (hasErrors) {
+      const missingPrice = rowErrors.some((e) => e.price);
+      const missingStock = rowErrors.some((e) => e.stock);
+      if (missingPrice && missingStock) {
+        toastError('Each option needs a price and stock greater than 0.');
+      } else if (missingPrice) {
+        toastError('Each option needs a price.');
+      } else if (missingStock) {
+        toastError('Each option needs stock greater than 0.');
+      } else {
+        toastError('Name each option when adding more than one.');
+      }
       return;
     }
 
-    if (variants.length > 1 && variants.some((v) => !v.label)) {
-      toastError('Label each variant when adding more than one.');
-      return;
-    }
+    const variants = createOptions.map((row) => {
+      const costRaw = row.costPrice.trim();
+      const costPrice = costRaw === '' ? null : Number(costRaw);
+      return {
+        label: row.label.trim(),
+        price: Number(row.price),
+        costPrice:
+          costPrice != null && Number.isFinite(costPrice) && costPrice >= 0
+            ? costPrice
+            : null,
+        stock: Number(row.stock),
+        lowStockThreshold: threshold,
+      };
+    });
 
     createM.mutate({
       name,
       variants,
+    });
+  }
+
+  function patchCreateRow(
+    idx: number,
+    patch: Partial<{ label: string; price: string; costPrice: string; stock: string }>,
+  ) {
+    setCreateOptions((prev) => {
+      const next = [...prev];
+      next[idx] = { ...next[idx], ...patch };
+      return next;
+    });
+    setCreateErrors((prev) => {
+      if (!prev[idx]) return prev;
+      const next = [...prev];
+      const cleared = { ...next[idx] };
+      if (patch.label !== undefined) delete cleared.label;
+      if (patch.price !== undefined) delete cleared.price;
+      if (patch.stock !== undefined) delete cleared.stock;
+      next[idx] = cleared;
+      return next;
     });
   }
 
@@ -358,26 +585,6 @@ export function ProductsPage() {
     }
   }
 
-  async function adjustStock(p: Product, op: '+' | '-') {
-    const quantity = Number(stockEdit[p.id]);
-    if (!Number.isFinite(quantity) || quantity <= 0) return;
-    if (guardDemoWrite('change products')) return;
-    const key = `${p.id}:${op}`;
-    try {
-      setRowBusy(key);
-      await updateStock(p.id, { op, quantity });
-      setStockEdit((prev) => ({ ...prev, [p.id]: '' }));
-      toastSuccess(
-        op === '+' ? `Added stock to ${p.name}` : `Reduced stock for ${p.name}`,
-      );
-      invalidate();
-    } catch (err) {
-      toastError(getErrorMessage(err));
-    } finally {
-      setRowBusy(null);
-    }
-  }
-
   async function confirmDelete() {
     if (!deleteTarget) return;
     if (guardDemoWrite('change products')) {
@@ -400,8 +607,13 @@ export function ProductsPage() {
   async function onAddVariant(p: Product) {
     if (guardDemoWrite('change products')) return;
     const price = Number(variantForm.price);
+    const stock = Number(variantForm.stock);
     if (!Number.isFinite(price) || price <= 0) {
-      toastError('Variant price must be greater than 0.');
+      toastError('Option price must be greater than 0.');
+      return;
+    }
+    if (!Number.isFinite(stock) || stock <= 0) {
+      toastError('Option stock must be greater than 0.');
       return;
     }
     try {
@@ -409,10 +621,11 @@ export function ProductsPage() {
       await addVariant(p.id, {
         label: variantForm.label.trim(),
         price,
-        stock: Number(variantForm.stock) || 0,
+        stock,
       });
-      setVariantForm({ label: '', price: '', stock: '0' });
-      toastSuccess(`Added variant to ${p.name}`);
+      setVariantForm({ label: '', price: '', stock: '' });
+      setPanelMode('list');
+      toastSuccess(`Added option to ${p.name}`);
       invalidate();
     } catch (err) {
       toastError(getErrorMessage(err));
@@ -426,7 +639,7 @@ export function ProductsPage() {
     const units = Number(packForm.unitsPerPack);
     const price = Number(packForm.price);
     if (!packForm.variantId) {
-      toastError('Choose which variant the pack belongs to.');
+      toastError('Choose which option the pack belongs to.');
       return;
     }
     if (!packForm.label.trim()) {
@@ -449,6 +662,7 @@ export function ProductsPage() {
         price,
       });
       setPackForm({ variantId: '', label: '', unitsPerPack: '24', price: '' });
+      setPanelMode('list');
       toastSuccess(`Added pack to ${p.name}`);
       invalidate();
     } catch (err) {
@@ -459,20 +673,26 @@ export function ProductsPage() {
   }
 
   function variantsOf(p: Product): ProductVariant[] {
-    return (p.variants || []).filter((v) => v.isActive !== false);
+    return activeVariants(p);
   }
 
   async function adjustVariantStock(p: Product, variantId: string, op: '+' | '-') {
     const key = `${variantId}`;
-    const quantity = Number(stockEdit[key]);
-    if (!Number.isFinite(quantity) || quantity <= 0) return;
+    const raw = String(stockEdit[key] ?? '').trim();
+    const quantity = raw === '' ? 1 : Number(raw);
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      toastError('Enter how many to add or take out.');
+      return;
+    }
     if (guardDemoWrite('change products')) return;
     const busy = `${p.id}:${variantId}:${op}`;
     try {
       setRowBusy(busy);
       await updateStock(p.id, { op, quantity, variantId });
       setStockEdit((prev) => ({ ...prev, [key]: '' }));
-      toastSuccess(op === '+' ? 'Stock added.' : 'Stock reduced.');
+      toastSuccess(
+        op === '+' ? `Added ${quantity} to stock.` : `Took out ${quantity} from stock.`,
+      );
       invalidate();
     } catch (err) {
       toastError(getErrorMessage(err));
@@ -486,8 +706,8 @@ export function ProductsPage() {
       <HeaderBlock>
         <PageTitle style={{ marginBottom: 8 }}>Products</PageTitle>
         <PageLead style={{ marginBottom: 0 }}>
-          Catalogue with variants (sizes, packs) and optional pack pricing. Stock
-          is tracked per variant; packs sell multiples of the same stock.
+          Add simple products, or products with options (500ml / 2L, Size 2, Red…) and
+          packs (crate, tray). Stock is counted per option.
         </PageLead>
       </HeaderBlock>
 
@@ -534,88 +754,87 @@ export function ProductsPage() {
             </Field>
           </Row>
 
-          {createOptions.map((row, idx) => (
-            <Row key={idx}>
-              <Field>
-                Variants (size, packs)
-                <Input
-                  placeholder="Optional — Size 2, 500ml, 1kg…"
-                  value={row.label}
-                  onChange={(e) => {
-                    const next = [...createOptions];
-                    next[idx] = { ...row, label: e.target.value };
-                    setCreateOptions(next);
-                  }}
-                />
-              </Field>
-              <Field>
-                Price
-                <Input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={row.price}
-                  onChange={(e) => {
-                    const next = [...createOptions];
-                    next[idx] = { ...row, price: e.target.value };
-                    setCreateOptions(next);
-                  }}
-                  required={idx === 0}
-                />
-              </Field>
-              <Field>
-                Cost
-                <Input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={row.costPrice}
-                  onChange={(e) => {
-                    const next = [...createOptions];
-                    next[idx] = { ...row, costPrice: e.target.value };
-                    setCreateOptions(next);
-                  }}
-                />
-              </Field>
-              <Field>
-                Stock
-                <Input
-                  type="number"
-                  min="0"
-                  value={row.stock}
-                  onChange={(e) => {
-                    const next = [...createOptions];
-                    next[idx] = { ...row, stock: e.target.value };
-                    setCreateOptions(next);
-                  }}
-                />
-              </Field>
-              {createOptions.length > 1 ? (
-                <Button
-                  type="button"
-                  $variant="ghost"
-                  onClick={() =>
-                    setCreateOptions(createOptions.filter((_, i) => i !== idx))
-                  }
-                >
-                  Remove
-                </Button>
-              ) : null}
-            </Row>
-          ))}
+          {createOptions.map((row, idx) => {
+            const errs = createErrors[idx] || {};
+            return (
+              <Row key={idx}>
+                <Field>
+                  Option name
+                  <Input
+                    placeholder="Optional — 500ml, Size 2, Red…"
+                    value={row.label}
+                    $invalid={Boolean(errs.label)}
+                    aria-invalid={Boolean(errs.label)}
+                    onChange={(e) => patchCreateRow(idx, { label: e.target.value })}
+                  />
+                  {errs.label ? <FieldHint $error>{errs.label}</FieldHint> : null}
+                </Field>
+                <Field>
+                  Price
+                  <Input
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={row.price}
+                    $invalid={Boolean(errs.price)}
+                    aria-invalid={Boolean(errs.price)}
+                    onChange={(e) => patchCreateRow(idx, { price: e.target.value })}
+                    required
+                  />
+                  {errs.price ? <FieldHint $error>{errs.price}</FieldHint> : null}
+                </Field>
+                <Field>
+                  Cost
+                  <Input
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={row.costPrice}
+                    onChange={(e) => patchCreateRow(idx, { costPrice: e.target.value })}
+                  />
+                </Field>
+                <Field>
+                  Stock
+                  <Input
+                    type="number"
+                    min="1"
+                    value={row.stock}
+                    $invalid={Boolean(errs.stock)}
+                    aria-invalid={Boolean(errs.stock)}
+                    onChange={(e) => patchCreateRow(idx, { stock: e.target.value })}
+                    required
+                  />
+                  {errs.stock ? <FieldHint $error>{errs.stock}</FieldHint> : null}
+                </Field>
+                {createOptions.length > 1 ? (
+                  <Button
+                    type="button"
+                    $variant="ghost"
+                    onClick={() => {
+                      setCreateOptions(createOptions.filter((_, i) => i !== idx));
+                      setCreateErrors((prev) => prev.filter((_, i) => i !== idx));
+                    }}
+                  >
+                    Remove
+                  </Button>
+                ) : null}
+              </Row>
+            );
+          })}
 
           <Row style={{ marginTop: 4 }}>
             <Button
               type="button"
               $variant="ghost"
-              onClick={() =>
+              onClick={() => {
                 setCreateOptions([
                   ...createOptions,
-                  { label: '', price: '', costPrice: '', stock: '0' },
-                ])
-              }
+                  { label: '', price: '', costPrice: '', stock: '' },
+                ]);
+                setCreateErrors([]);
+              }}
             >
-              + Variant
+              + Add option
             </Button>
             <Button type="submit" loading={createM.isPending}>
               {createM.isPending ? 'Adding…' : 'Add'}
@@ -650,9 +869,9 @@ export function ProductsPage() {
       <Card>
         {productsQ.isLoading ? (
           <TableSkeleton
-            columns={6}
+            columns={5}
             rows={8}
-            widths={['9rem', '3.5rem', '4.5rem', '4.5rem', '6.5rem', '3.5rem']}
+            widths={['9rem', '3.5rem', '4.5rem', '4.5rem', '5rem']}
           />
         ) : (
           <Table>
@@ -662,7 +881,6 @@ export function ProductsPage() {
                 <th>Stock</th>
                 <th>Price</th>
                 <th>Cost</th>
-                <th>Adjust</th>
                 <th />
               </tr>
             </thead>
@@ -673,369 +891,66 @@ export function ProductsPage() {
                 const multi = productHasOptions(p);
                 const expanded = expandedId === p.id;
                 return (
-                  <Fragment key={p.id}>
-                    <tr>
-                      <td>
-                        <NameCell>
-                          <Truncate title={p.name}>{p.name}</Truncate>
-                          {multi ? (
-                            <Badge $tone="info">{variants.length} opt</Badge>
-                          ) : null}
-                          {status === 'out' ? <Badge $tone="danger">Out</Badge> : null}
-                          {status === 'low' ? <Badge $tone="warning">Low</Badge> : null}
-                        </NameCell>
-                      </td>
-                      <td>{p.trackStock ? p.stock : '—'}</td>
-                      <td>
-                        <CompactInput
-                          type="number"
-                          min="0"
-                          step="0.01"
-                          defaultValue={p.price}
-                          key={`price-${p.id}-${p.price}`}
-                          onBlur={(e) => void savePrice(p, e.target.value)}
-                        />
-                      </td>
-                      <td>
-                        <CompactInput
-                          type="number"
-                          min="0"
-                          step="0.01"
-                          defaultValue={p.costPrice ?? ''}
-                          key={`cost-${p.id}-${p.costPrice ?? 'x'}`}
-                          placeholder="—"
-                          onBlur={(e) => void saveCost(p, e.target.value)}
-                        />
-                      </td>
-                      <td>
-                        <AdjustGroup>
-                          <QtyInput
-                            type="number"
-                            min="1"
-                            placeholder="1"
-                            aria-label={`Adjust quantity for ${p.name}`}
-                            value={stockEdit[p.id] || ''}
-                            disabled={!p.trackStock || multi}
-                            onChange={(e) =>
-                              setStockEdit({
-                                ...stockEdit,
-                                [p.id]: e.target.value,
-                              })
-                            }
-                          />
-                          <StepBtn
-                            type="button"
-                            aria-label={`Add stock for ${p.name}`}
-                            disabled={!p.trackStock || multi || rowBusy === `${p.id}:+`}
-                            onClick={() => void adjustStock(p, '+')}
-                          >
-                            {rowBusy === `${p.id}:+` ? '…' : '+'}
-                          </StepBtn>
-                          <StepBtn
-                            type="button"
-                            aria-label={`Remove stock for ${p.name}`}
-                            disabled={!p.trackStock || multi || rowBusy === `${p.id}:-`}
-                            onClick={() => void adjustStock(p, '-')}
-                          >
-                            {rowBusy === `${p.id}:-` ? '…' : '−'}
-                          </StepBtn>
-                        </AdjustGroup>
-                      </td>
-                      <td>
-                        <Row style={{ gap: 6, margin: 0, flexWrap: 'nowrap' }}>
-                          <Button
-                            type="button"
-                            $variant="ghost"
-                            $size="sm"
-                            onClick={() => {
-                              setExpandedId(expanded ? null : p.id);
-                              const first = variants[0];
-                              if (first) {
-                                setPackForm((prev) => ({
-                                  ...prev,
-                                  variantId: first.id,
-                                }));
-                              }
-                            }}
-                          >
-                            {expanded ? 'Hide' : 'Variants'}
-                          </Button>
-                          <Button
-                            type="button"
-                            $variant="danger"
-                            $size="sm"
-                            loading={rowBusy === `del:${p.id}`}
-                            onClick={() => setDeleteTarget(p)}
-                          >
-                            {rowBusy === `del:${p.id}` ? '…' : 'Delete'}
-                          </Button>
-                        </Row>
-                      </td>
-                    </tr>
-                    {expanded ? (
-                      <tr>
-                        <td colSpan={6}>
-                          <div style={{ padding: '8px 0 12px' }}>
-                            {variants.map((v) => {
-                              const packs = (v.packs || []).filter(
-                                (pk) => pk.isActive !== false,
-                              );
-                              return (
-                                <div
-                                  key={v.id}
-                                  style={{
-                                    marginBottom: 12,
-                                    paddingBottom: 8,
-                                    borderBottom: '1px solid var(--border, #ddd)',
-                                  }}
-                                >
-                                  <Row
-                                    style={{
-                                      alignItems: 'center',
-                                      marginBottom: 6,
-                                    }}
-                                  >
-                                    <strong>{v.label?.trim() || 'Default'}</strong>
-                                    <span>
-                                      {v.trackStock ? `Stock ${v.stock}` : 'Stock off'} ·{' '}
-                                      {money(v.price)}
-                                    </span>
-                                    <AdjustGroup>
-                                      <QtyInput
-                                        type="number"
-                                        min="1"
-                                        placeholder="1"
-                                        value={stockEdit[v.id] || ''}
-                                        disabled={!v.trackStock}
-                                        onChange={(e) =>
-                                          setStockEdit({
-                                            ...stockEdit,
-                                            [v.id]: e.target.value,
-                                          })
-                                        }
-                                      />
-                                      <StepBtn
-                                        type="button"
-                                        disabled={
-                                          !v.trackStock || rowBusy === `${p.id}:${v.id}:+`
-                                        }
-                                        onClick={() =>
-                                          void adjustVariantStock(p, v.id, '+')
-                                        }
-                                      >
-                                        +
-                                      </StepBtn>
-                                      <StepBtn
-                                        type="button"
-                                        disabled={
-                                          !v.trackStock || rowBusy === `${p.id}:${v.id}:-`
-                                        }
-                                        onClick={() =>
-                                          void adjustVariantStock(p, v.id, '-')
-                                        }
-                                      >
-                                        −
-                                      </StepBtn>
-                                    </AdjustGroup>
-                                    {variants.length > 1 ? (
-                                      <Button
-                                        type="button"
-                                        $variant="ghost"
-                                        $size="sm"
-                                        onClick={() => {
-                                          if (guardDemoWrite('change products')) return;
-                                          void deleteVariant(p.id, v.id)
-                                            .then(() => {
-                                              toastSuccess('Variant removed.');
-                                              invalidate();
-                                            })
-                                            .catch((err) =>
-                                              toastError(getErrorMessage(err)),
-                                            );
-                                        }}
-                                      >
-                                        Remove variant
-                                      </Button>
-                                    ) : null}
-                                  </Row>
-                                  <div
-                                    style={{
-                                      fontSize: '0.88rem',
-                                      color: 'inherit',
-                                      opacity: 0.85,
-                                    }}
-                                  >
-                                    Packs:{' '}
-                                    {packs
-                                      .map(
-                                        (pk) =>
-                                          `${pk.label} (${pk.unitsPerPack}) ${money(pk.price)}`,
-                                      )
-                                      .join(' · ')}
-                                  </div>
-                                  {packs.length > 1
-                                    ? packs
-                                        .filter((pk) => pk.unitsPerPack !== 1)
-                                        .map((pk) => (
-                                          <Button
-                                            key={pk.id}
-                                            type="button"
-                                            $variant="ghost"
-                                            $size="sm"
-                                            style={{ marginTop: 4 }}
-                                            onClick={() => {
-                                              if (guardDemoWrite('change products'))
-                                                return;
-                                              void deletePack(p.id, v.id, pk.id)
-                                                .then(() => {
-                                                  toastSuccess('Pack removed.');
-                                                  invalidate();
-                                                })
-                                                .catch((err) =>
-                                                  toastError(getErrorMessage(err)),
-                                                );
-                                            }}
-                                          >
-                                            Remove {pk.label}
-                                          </Button>
-                                        ))
-                                    : null}
-                                </div>
-                              );
-                            })}
-
-                            <Row style={{ alignItems: 'flex-end' }}>
-                              <Field>
-                                Variant label
-                                <Input
-                                  placeholder="e.g. Size 2 / 1kg"
-                                  value={variantForm.label}
-                                  onChange={(e) =>
-                                    setVariantForm({
-                                      ...variantForm,
-                                      label: e.target.value,
-                                    })
-                                  }
-                                />
-                              </Field>
-                              <Field>
-                                Price
-                                <Input
-                                  type="number"
-                                  min="0"
-                                  step="0.01"
-                                  value={variantForm.price}
-                                  onChange={(e) =>
-                                    setVariantForm({
-                                      ...variantForm,
-                                      price: e.target.value,
-                                    })
-                                  }
-                                />
-                              </Field>
-                              <Field>
-                                Stock
-                                <Input
-                                  type="number"
-                                  min="0"
-                                  value={variantForm.stock}
-                                  onChange={(e) =>
-                                    setVariantForm({
-                                      ...variantForm,
-                                      stock: e.target.value,
-                                    })
-                                  }
-                                />
-                              </Field>
-                              <Button
-                                type="button"
-                                loading={rowBusy === `var:${p.id}`}
-                                onClick={() => void onAddVariant(p)}
-                              >
-                                Add variant
-                              </Button>
-                            </Row>
-
-                            <Row style={{ alignItems: 'flex-end' }}>
-                              <Field>
-                                Pack for variant
-                                <select
-                                  value={packForm.variantId}
-                                  onChange={(e) =>
-                                    setPackForm({
-                                      ...packForm,
-                                      variantId: e.target.value,
-                                    })
-                                  }
-                                  style={{
-                                    width: '100%',
-                                    minHeight: 40,
-                                    padding: '0 8px',
-                                  }}
-                                >
-                                  <option value="">Select…</option>
-                                  {variants.map((v) => (
-                                    <option key={v.id} value={v.id}>
-                                      {v.label?.trim() || 'Default'}
-                                    </option>
-                                  ))}
-                                </select>
-                              </Field>
-                              <Field>
-                                Pack label
-                                <Input
-                                  placeholder="e.g. Crate"
-                                  value={packForm.label}
-                                  onChange={(e) =>
-                                    setPackForm({
-                                      ...packForm,
-                                      label: e.target.value,
-                                    })
-                                  }
-                                />
-                              </Field>
-                              <Field>
-                                Units / pack
-                                <Input
-                                  type="number"
-                                  min="1"
-                                  value={packForm.unitsPerPack}
-                                  onChange={(e) =>
-                                    setPackForm({
-                                      ...packForm,
-                                      unitsPerPack: e.target.value,
-                                    })
-                                  }
-                                />
-                              </Field>
-                              <Field>
-                                Pack price
-                                <Input
-                                  type="number"
-                                  min="0"
-                                  step="0.01"
-                                  value={packForm.price}
-                                  onChange={(e) =>
-                                    setPackForm({
-                                      ...packForm,
-                                      price: e.target.value,
-                                    })
-                                  }
-                                />
-                              </Field>
-                              <Button
-                                type="button"
-                                loading={rowBusy === `pack:${p.id}`}
-                                onClick={() => void onAddPack(p)}
-                              >
-                                Add pack
-                              </Button>
-                            </Row>
-                          </div>
-                        </td>
-                      </tr>
-                    ) : null}
-                  </Fragment>
+                  <tr key={p.id}>
+                    <td>
+                      <NameCell>
+                        <Truncate title={p.name}>{p.name}</Truncate>
+                        {multi ? (
+                          <Badge $tone="info">
+                            {variants.length} option{variants.length === 1 ? '' : 's'}
+                          </Badge>
+                        ) : null}
+                        {status === 'out' ? <Badge $tone="danger">Out</Badge> : null}
+                        {status === 'low' ? <Badge $tone="warning">Low</Badge> : null}
+                      </NameCell>
+                    </td>
+                    <td>{p.trackStock ? p.stock : '—'}</td>
+                    <td>
+                      <CompactInput
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        defaultValue={p.price}
+                        key={`price-${p.id}-${p.price}`}
+                        onBlur={(e) => void savePrice(p, e.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <CompactInput
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        defaultValue={p.costPrice ?? ''}
+                        key={`cost-${p.id}-${p.costPrice ?? 'x'}`}
+                        placeholder="—"
+                        onBlur={(e) => void saveCost(p, e.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <Row style={{ gap: 6, margin: 0, flexWrap: 'nowrap' }}>
+                        <Button
+                          type="button"
+                          $variant="ghost"
+                          $size="sm"
+                          onClick={() => {
+                            if (expanded) closeEditPanel();
+                            else openEditPanel(p);
+                          }}
+                        >
+                          {expanded ? 'Close' : 'Edit'}
+                        </Button>
+                        <Button
+                          type="button"
+                          $variant="danger"
+                          $size="sm"
+                          loading={rowBusy === `del:${p.id}`}
+                          onClick={() => setDeleteTarget(p)}
+                        >
+                          {rowBusy === `del:${p.id}` ? '…' : 'Delete'}
+                        </Button>
+                      </Row>
+                    </td>
+                  </tr>
                 );
               })}
             </tbody>
@@ -1045,6 +960,367 @@ export function ProductsPage() {
           <p style={{ marginBottom: 0 }}>
             {products.length === 0 ? 'No products yet.' : 'No matching products.'}
           </p>
+        ) : null}
+
+        {expandedProduct ? (
+          <VariantsPanel>
+            <PanelHeader>
+              <div>
+                <PanelTitle>Edit {expandedProduct.name}</PanelTitle>
+                <PanelLead>
+                  Change the name, update stock here, or add another option (size, colour,
+                  flavour…). Packs are optional.
+                </PanelLead>
+              </div>
+              <Button type="button" $variant="ghost" $size="sm" onClick={closeEditPanel}>
+                Done
+              </Button>
+            </PanelHeader>
+
+            <Row style={{ alignItems: 'flex-end', marginBottom: 16 }}>
+              <Field>
+                Product name
+                <Input
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onBlur={() => void saveProductName(expandedProduct)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      void saveProductName(expandedProduct);
+                    }
+                  }}
+                />
+              </Field>
+            </Row>
+
+            <SizeList>
+              {variantsOf(expandedProduct).map((v) => {
+                const packs = (v.packs || []).filter((pk) => pk.isActive !== false);
+                const variants = variantsOf(expandedProduct);
+                const packSummary = packs
+                  .map((pk) =>
+                    pk.unitsPerPack === 1
+                      ? `Single ${money(pk.price)}`
+                      : `${pk.label} of ${pk.unitsPerPack} · ${money(pk.price)}`,
+                  )
+                  .join(' · ');
+                return (
+                  <SizeRow key={v.id}>
+                    <SizeMeta>
+                      <SizeName>{v.label?.trim() || 'Standard'}</SizeName>
+                      <SizeDetails>
+                        Sell price {money(v.price)}
+                        {packSummary ? ` · ${packSummary}` : ''}
+                      </SizeDetails>
+                      <SizeStock>
+                        {v.trackStock ? `${v.stock} in stock` : 'Stock tracking off'}
+                      </SizeStock>
+                    </SizeMeta>
+                    <SizeActions>
+                      {v.trackStock ? (
+                        <>
+                          <StockLabel>Change stock</StockLabel>
+                          <AdjustGroup>
+                            <QtyInput
+                              type="number"
+                              min="1"
+                              placeholder="1"
+                              aria-label={`How many to change for ${v.label || expandedProduct.name}`}
+                              value={stockEdit[v.id] || ''}
+                              onChange={(e) =>
+                                setStockEdit({
+                                  ...stockEdit,
+                                  [v.id]: e.target.value,
+                                })
+                              }
+                            />
+                            <StepBtn
+                              type="button"
+                              title="Add stock"
+                              aria-label="Add stock"
+                              disabled={rowBusy === `${expandedProduct.id}:${v.id}:+`}
+                              onClick={() =>
+                                void adjustVariantStock(expandedProduct, v.id, '+')
+                              }
+                            >
+                              +
+                            </StepBtn>
+                            <StepBtn
+                              type="button"
+                              title="Take out stock"
+                              aria-label="Take out stock"
+                              disabled={rowBusy === `${expandedProduct.id}:${v.id}:-`}
+                              onClick={() =>
+                                void adjustVariantStock(expandedProduct, v.id, '-')
+                              }
+                            >
+                              −
+                            </StepBtn>
+                          </AdjustGroup>
+                        </>
+                      ) : null}
+                      {variants.length > 1 ? (
+                        <Button
+                          type="button"
+                          $variant="ghost"
+                          $size="sm"
+                          onClick={() => {
+                            if (guardDemoWrite('change products')) return;
+                            const label = v.label?.trim() || 'this option';
+                            if (
+                              !window.confirm(
+                                `Remove ${label} from ${expandedProduct.name}?`,
+                              )
+                            ) {
+                              return;
+                            }
+                            void deleteVariant(expandedProduct.id, v.id)
+                              .then(() => {
+                                toastSuccess('Option removed.');
+                                invalidate();
+                              })
+                              .catch((err) => toastError(getErrorMessage(err)));
+                          }}
+                        >
+                          Remove
+                        </Button>
+                      ) : null}
+                      {packs.length > 1
+                        ? packs
+                            .filter((pk) => pk.unitsPerPack !== 1)
+                            .map((pk) => (
+                              <Button
+                                key={pk.id}
+                                type="button"
+                                $variant="ghost"
+                                $size="sm"
+                                onClick={() => {
+                                  if (guardDemoWrite('change products')) return;
+                                  if (
+                                    !window.confirm(
+                                      `Stop selling ${pk.label} for ${v.label?.trim() || expandedProduct.name}?`,
+                                    )
+                                  ) {
+                                    return;
+                                  }
+                                  void deletePack(expandedProduct.id, v.id, pk.id)
+                                    .then(() => {
+                                      toastSuccess('Pack removed.');
+                                      invalidate();
+                                    })
+                                    .catch((err) => toastError(getErrorMessage(err)));
+                                }}
+                              >
+                                Remove {pk.label}
+                              </Button>
+                            ))
+                        : null}
+                    </SizeActions>
+                  </SizeRow>
+                );
+              })}
+            </SizeList>
+
+            {panelMode === 'list' ? (
+              <SecondaryActions>
+                <Button
+                  type="button"
+                  $variant="ghost"
+                  onClick={() => setPanelMode('add-option')}
+                >
+                  + Add option
+                </Button>
+                <Button
+                  type="button"
+                  $variant="ghost"
+                  onClick={() => {
+                    const first = variantsOf(expandedProduct)[0];
+                    setPackForm((prev) => ({
+                      ...prev,
+                      variantId: prev.variantId || first?.id || '',
+                    }));
+                    setPanelMode('add-pack');
+                  }}
+                >
+                  + Sell in packs (crate, tray…)
+                </Button>
+              </SecondaryActions>
+            ) : null}
+
+            {panelMode === 'add-option' ? (
+              <AddSection>
+                <AddSectionTitle>Add option</AddSectionTitle>
+                <AddSectionLead>
+                  Examples: 500ml, Size 2, Red, 1kg. Needs its own price and starting
+                  stock.
+                </AddSectionLead>
+                <Row style={{ alignItems: 'flex-end' }}>
+                  <Field>
+                    Option name
+                    <Input
+                      placeholder="e.g. 500ml / Size 2 / Red"
+                      value={variantForm.label}
+                      onChange={(e) =>
+                        setVariantForm({
+                          ...variantForm,
+                          label: e.target.value,
+                        })
+                      }
+                    />
+                  </Field>
+                  <Field>
+                    Price
+                    <Input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={variantForm.price}
+                      onChange={(e) =>
+                        setVariantForm({
+                          ...variantForm,
+                          price: e.target.value,
+                        })
+                      }
+                    />
+                  </Field>
+                  <Field>
+                    Starting stock
+                    <Input
+                      type="number"
+                      min="1"
+                      placeholder="Required"
+                      value={variantForm.stock}
+                      onChange={(e) =>
+                        setVariantForm({
+                          ...variantForm,
+                          stock: e.target.value,
+                        })
+                      }
+                    />
+                  </Field>
+                  <Button
+                    type="button"
+                    loading={rowBusy === `var:${expandedProduct.id}`}
+                    onClick={() => void onAddVariant(expandedProduct)}
+                  >
+                    Save option
+                  </Button>
+                  <Button
+                    type="button"
+                    $variant="ghost"
+                    onClick={() => {
+                      setPanelMode('list');
+                      setVariantForm({ label: '', price: '', stock: '' });
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </Row>
+              </AddSection>
+            ) : null}
+
+            {panelMode === 'add-pack' ? (
+              <AddSection>
+                <AddSectionTitle>Sell in packs</AddSectionTitle>
+                <AddSectionLead>
+                  Same stock, sold as a group — e.g. a crate of 24. Pick which option the
+                  pack belongs to.
+                </AddSectionLead>
+                <Row style={{ alignItems: 'flex-end' }}>
+                  <Field style={{ flex: '1.4 1 180px' }}>
+                    Which option?
+                    <Select
+                      key={`pack-variant-${expandedProduct.id}-${variantsOf(
+                        expandedProduct,
+                      )
+                        .map((v) => v.id)
+                        .join('-')}`}
+                      value={packForm.variantId}
+                      onChange={(e) =>
+                        setPackForm({
+                          ...packForm,
+                          variantId: e.target.value,
+                        })
+                      }
+                    >
+                      <option value="">Choose…</option>
+                      {variantsOf(expandedProduct).map((v) => (
+                        <option key={v.id} value={v.id}>
+                          {v.label?.trim() || 'Standard'}
+                          {v.trackStock ? ` (${v.stock} in stock)` : ''}
+                        </option>
+                      ))}
+                    </Select>
+                  </Field>
+                  <Field>
+                    Pack name
+                    <Input
+                      placeholder="e.g. Crate"
+                      value={packForm.label}
+                      onChange={(e) =>
+                        setPackForm({
+                          ...packForm,
+                          label: e.target.value,
+                        })
+                      }
+                    />
+                  </Field>
+                  <Field>
+                    How many inside?
+                    <Input
+                      type="number"
+                      min="1"
+                      value={packForm.unitsPerPack}
+                      onChange={(e) =>
+                        setPackForm({
+                          ...packForm,
+                          unitsPerPack: e.target.value,
+                        })
+                      }
+                    />
+                  </Field>
+                  <Field>
+                    Pack price
+                    <Input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={packForm.price}
+                      onChange={(e) =>
+                        setPackForm({
+                          ...packForm,
+                          price: e.target.value,
+                        })
+                      }
+                    />
+                  </Field>
+                  <Button
+                    type="button"
+                    loading={rowBusy === `pack:${expandedProduct.id}`}
+                    onClick={() => void onAddPack(expandedProduct)}
+                  >
+                    Save pack
+                  </Button>
+                  <Button
+                    type="button"
+                    $variant="ghost"
+                    onClick={() => {
+                      setPanelMode('list');
+                      setPackForm((prev) => ({
+                        ...prev,
+                        label: '',
+                        unitsPerPack: '24',
+                        price: '',
+                      }));
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </Row>
+              </AddSection>
+            ) : null}
+          </VariantsPanel>
         ) : null}
       </Card>
 

--- a/frontend/src/pages/SalesPage.tsx
+++ b/frontend/src/pages/SalesPage.tsx
@@ -321,8 +321,8 @@ export function SalesPage() {
     <Page>
       <PageTitle>Sales</PageTitle>
       <PageLead>
-        Cash, credit, and customer sales. Size and pack pickers appear when a product has
-        options.
+        Cash, credit, and customer sales. Option and pack pickers appear when a product
+        has them.
       </PageLead>
 
       <Tabs>

--- a/frontend/src/utils/productCatalog.ts
+++ b/frontend/src/utils/productCatalog.ts
@@ -18,8 +18,27 @@ export function emptyCatalogLine(): CatalogLine {
   };
 }
 
+function variantIdOf(v: ProductVariant & { _id?: string }): string {
+  return String(v.id || v._id || '').trim();
+}
+
+function packIdOf(pk: ProductPack & { _id?: string }): string {
+  return String(pk.id || pk._id || '').trim();
+}
+
+/** Active variants with stable string ids (defensive if API ever returns `_id`). */
 export function activeVariants(product: Product | undefined): ProductVariant[] {
-  return (product?.variants || []).filter((v) => v.isActive !== false);
+  return (product?.variants || [])
+    .filter((v) => v && v.isActive !== false)
+    .map((v) => {
+      const id = variantIdOf(v);
+      const packs = (v.packs || [])
+        .filter((pk) => pk && pk.isActive !== false)
+        .map((pk) => ({ ...pk, id: packIdOf(pk) || pk.id }))
+        .filter((pk) => Boolean(pk.id));
+      return { ...v, id, packs };
+    })
+    .filter((v) => Boolean(v.id));
 }
 
 export function activePacks(
@@ -27,7 +46,7 @@ export function activePacks(
   variantId: string,
 ): ProductPack[] {
   const variant = activeVariants(product).find((v) => v.id === variantId);
-  return (variant?.packs || []).filter((pk) => pk.isActive !== false);
+  return variant?.packs || [];
 }
 
 export function pickDefaultIds(product: Product | undefined): {


### PR DESCRIPTION
Replace the clipped Variants table expand with a product Edit flow, block incomplete option rows with highlighted errors, and move stock adjustments out of the catalogue table.